### PR TITLE
[FCE-802] Fix param name

### DIFF
--- a/docs/react-native/start-streaming.mdx
+++ b/docs/react-native/start-streaming.mdx
@@ -26,7 +26,7 @@ function Component() {
   const { prepareCamera } = useCamera();
 
   useEffect(() => {
-    prepareCamera({ enableCamera: true });
+    prepareCamera({ cameraEnabled: true });
   }, [])
 
   return <VideoPreviewView />


### PR DESCRIPTION
## Description

There was bug in param description, where `enableCamera` was used instead of `cameraEnabled`.

I'm also adding missing `yarn` configuration, as it caused some issues on my machine (not sure how it worked, without ti 🤔 )