### PR TITLE
Add serverside livestreaming docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -88,5 +88,7 @@ WebGPU
 Three.js
 PixiJS
 MediaStream
+WHEP
+livestream
 livestreaming
 broadcasted

--- a/docs/livestreaming.mdx
+++ b/docs/livestreaming.mdx
@@ -1,0 +1,78 @@
+---
+sidebar_position: 5
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# Livestreaming
+
+For livestreaming purposes we suggest using livestream rooms specifically optimized for this use case.
+
+Main differences:
+*  Livestream rooms are 20% cheaper than regular rooms
+*  Livestream rooms allows for greater scalability
+*  Compatible with WHEP standard 
+<!-- *  TODO: compatibility with WHIP -->
+
+## How Do I Use It?
+### Streamer
+To create a livestream room, you must set the `roomType` field to `broadcaster` when creating a room using our [Server SDKs](/production/server). Then you have to create one peer that will be used to stream your content.
+
+<Tabs groupId="language">
+  <TabItem value="ts" label="Typescript">
+  
+    ```ts
+    const createdRoom = await fishjamClient.createRoom({ roomType: 'broadcaster' });
+
+    const peer = await fishjamClient.createPeer(createdRoom.id)
+    ```
+
+  </TabItem>
+
+  <TabItem value="python" label="Python">
+
+    ```python
+    options = RoomOptions(room_type="broadcaster")
+    created_room = fishjam_client.create_room(options)
+
+    peer = fishjam_client.create_peer(created_room.id)
+    ```
+
+  </TabItem>
+ </Tabs>
+
+Now, you can connect peer normally to the room as described in our [React Native](/react-native/connecting) and [React](/react/connecting)  docs.
+
+:::info
+The livestream rooms support only one video and audio track; any additional tracks will be ignored and will not be available to the viewers.
+:::
+
+### Viewers
+To view the streamed content you need to obtain viewer token that can be generated using [Server SDKs](/production/server).
+
+<Tabs groupId="language">
+  <TabItem value="ts" label="Typescript">
+  
+    ```ts
+    // createdRoom ... previously created room
+    const viewerToken = await fishjamClient.createBroadcastViewerToken(createdRoom.id)
+    ```
+
+  </TabItem>
+
+  <TabItem value="python" label="Python">
+
+    ```python
+    # created_room ... previously created room
+    viewer_token = fishjam_client.create_livestream_viewer_token(created_room.id)
+    ```
+
+  </TabItem>
+ </Tabs>
+
+Now you can connect viewer to the livestream as described in our [React Native] and [React] docs.
+
+:::info
+Viewers connect using [WHEP](https://blog.swmansion.com/introducing-react-native-whip-whep-ac9e5588d4da) standard, allowing the use of any player that supports the WHEP standard.
+:::

--- a/docs/livestreaming.mdx
+++ b/docs/livestreaming.mdx
@@ -5,9 +5,9 @@ sidebar_position: 5
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Livestreaming
+# Live streaming
 
-For livestreaming purposes we suggest using livestream rooms specifically optimized for this use case.
+For live streaming purposes we suggest using livestream rooms specifically optimized for this use case.
 
 Main differences:
 *  Livestream rooms are 20% cheaper than regular rooms

--- a/docs/livestreaming.mdx
+++ b/docs/livestreaming.mdx
@@ -10,13 +10,16 @@ import TabItem from "@theme/TabItem";
 For live streaming purposes we suggest using livestream rooms specifically optimized for this use case.
 
 Main differences:
-*  Livestream rooms are 20% cheaper than regular rooms
-*  Livestream rooms allows for greater scalability
-*  Compatible with WHEP standard 
+
+- Livestream rooms are 20% cheaper than regular rooms
+- Livestream rooms allows for greater scalability
+- Compatible with WHEP standard
 <!-- *  TODO: compatibility with WHIP -->
 
 ## How Do I Use It?
+
 ### Streamer
+
 To create a livestream room, you must set the `roomType` field to `broadcaster` when creating a room using our [Server SDKs](/production/server). Then you have to create one peer that will be used to stream your content.
 
 <Tabs groupId="language">
@@ -42,13 +45,14 @@ To create a livestream room, you must set the `roomType` field to `broadcaster` 
   </TabItem>
  </Tabs>
 
-Now, you can connect peer normally to the room as described in our [React Native](/react-native/connecting) and [React](/react/connecting)  docs.
+Now, you can connect peer normally to the room as described in our [React Native](/react-native/connecting) and [React](/react/connecting) docs.
 
 :::info
 The livestream rooms support only one video and audio track; any additional tracks will be ignored and will not be available to the viewers.
 :::
 
 ### Viewers
+
 To view the streamed content you need to obtain viewer token that can be generated using [Server SDKs](/production/server).
 
 <Tabs groupId="language">

--- a/docs/livestreaming.mdx
+++ b/docs/livestreaming.mdx
@@ -5,22 +5,25 @@ sidebar_position: 5
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Live streaming
+# Livestreaming
 
-For live streaming purposes, we suggest using livestream rooms that are specifically optimized for the one-to-many scenario.
+If your case involves streaming live audio and/or video from one source to many viewers with low latency, Fishjam provides the exact tools you need. This scenario is 20% cheaper than videoconferencing.
 
-The main differences are:
-
-- Livestream rooms are 20% cheaper than regular rooms
-- Livestream rooms are optimized for one-to-many scenario and allow for hundreds of people to participate
-- Compatible with WHEP standard
-<!-- *  TODO: compatibility with WHIP -->
-
-## How do I use it?
+## How Do I Use It?
 
 ### Streamer
 
-To create a livestream room, you must set the `roomType` field to `livestream` when creating a room using our [Server SDKs](/production/server). Then you have to create a peer that will be used to stream your content.
+First, you need to create a room with the livestream type using our [Server SDKs](/production/server). If you are using our sandbox, the [Room Manager](/room-manager) also allows you to create such a room. As the streaming is one-to-many, you can have only one streaming participant in that room.
+
+#### Using Room Manager
+
+You can create a livestream room and obtain a peer token using this URL:
+
+```
+https://fishjam.io/api/v1/connect/<YOUR_APP_UUID>/room-manager?roomName=foo&peerName=bar&roomType=livestream
+```
+
+#### Using Server SDKs
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -45,7 +48,7 @@ To create a livestream room, you must set the `roomType` field to `livestream` w
   </TabItem>
  </Tabs>
 
-Now, you can connect the peer normally to the room as described in our [React Native](/react-native/connecting) and [React](/react/connecting) docs.
+Now, you can connect to the room and start streaming as described in our [React Native](/react-native/connecting) and [React](/react/connecting) docs.
 
 :::info
 The livestream rooms support only one video and audio track; any additional tracks will be ignored and will not be available to the viewers.
@@ -53,14 +56,21 @@ The livestream rooms support only one video and audio track; any additional trac
 
 ### Viewers
 
-To view the streamed content, you need to obtain a viewer token that can be generated using [Server SDKs](/production/server).
+To view the streamed content, you need to obtain a viewer token that can be generated using [Server SDKs](/production/server). If you are using our sandbox, the [Room Manager](/room-manager) also allows you to create such a token.
+
+#### Using Room Manager
+
+```
+https://fishjam.io/api/v1/connect/<YOUR_APP_UUID>/room-manager/<ROOM_NAME>/livestream-viewer-token
+```
+
+#### Using Server SDKs
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
   
     ```ts
-    // createdRoom ... previously created room
-    const viewerToken = await fishjamClient.createBroadcastViewerToken(createdRoom.id)
+    const viewerToken = await fishjamClient.createLivestreamViewerToken(room.id)
     ```
 
   </TabItem>
@@ -68,14 +78,13 @@ To view the streamed content, you need to obtain a viewer token that can be gene
   <TabItem value="python" label="Python">
 
     ```python
-    # created_room ... previously created room
-    viewer_token = fishjam_client.create_livestream_viewer_token(created_room.id)
+    viewer_token = fishjam_client.create_livestream_viewer_token(room.id)
     ```
 
   </TabItem>
  </Tabs>
 
-Now you can connect the viewer to the livestream as described in our [React Native] and [React] docs.
+Now you can connect the viewer to the livestream as described in our React Native and [React](/react/livestreaming) docs.
 
 :::info
 Viewers connect using [WHEP](https://blog.swmansion.com/introducing-react-native-whip-whep-ac9e5588d4da) standard, allowing the use of any player that supports the WHEP standard.

--- a/docs/livestreaming.mdx
+++ b/docs/livestreaming.mdx
@@ -7,26 +7,26 @@ import TabItem from "@theme/TabItem";
 
 # Live streaming
 
-For live streaming purposes we suggest using livestream rooms specifically optimized for this use case.
+For live streaming purposes, we suggest using livestream rooms that are specifically optimized for the one-to-many scenario.
 
-Main differences:
+The main differences are:
 
 - Livestream rooms are 20% cheaper than regular rooms
-- Livestream rooms allows for greater scalability
+- Livestream rooms are optimized for one-to-many scenario and allow for hundreds of people to participate
 - Compatible with WHEP standard
 <!-- *  TODO: compatibility with WHIP -->
 
-## How Do I Use It?
+## How do I use it?
 
 ### Streamer
 
-To create a livestream room, you must set the `roomType` field to `broadcaster` when creating a room using our [Server SDKs](/production/server). Then you have to create one peer that will be used to stream your content.
+To create a livestream room, you must set the `roomType` field to `livestream` when creating a room using our [Server SDKs](/production/server). Then you have to create a peer that will be used to stream your content.
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
   
     ```ts
-    const createdRoom = await fishjamClient.createRoom({ roomType: 'broadcaster' });
+    const createdRoom = await fishjamClient.createRoom({ roomType: 'livestream' });
 
     const peer = await fishjamClient.createPeer(createdRoom.id)
     ```
@@ -36,7 +36,7 @@ To create a livestream room, you must set the `roomType` field to `broadcaster` 
   <TabItem value="python" label="Python">
 
     ```python
-    options = RoomOptions(room_type="broadcaster")
+    options = RoomOptions(room_type="livestream")
     created_room = fishjam_client.create_room(options)
 
     peer = fishjam_client.create_peer(created_room.id)
@@ -45,7 +45,7 @@ To create a livestream room, you must set the `roomType` field to `broadcaster` 
   </TabItem>
  </Tabs>
 
-Now, you can connect peer normally to the room as described in our [React Native](/react-native/connecting) and [React](/react/connecting) docs.
+Now, you can connect the peer normally to the room as described in our [React Native](/react-native/connecting) and [React](/react/connecting) docs.
 
 :::info
 The livestream rooms support only one video and audio track; any additional tracks will be ignored and will not be available to the viewers.
@@ -53,7 +53,7 @@ The livestream rooms support only one video and audio track; any additional trac
 
 ### Viewers
 
-To view the streamed content you need to obtain viewer token that can be generated using [Server SDKs](/production/server).
+To view the streamed content, you need to obtain a viewer token that can be generated using [Server SDKs](/production/server).
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -75,7 +75,7 @@ To view the streamed content you need to obtain viewer token that can be generat
   </TabItem>
  </Tabs>
 
-Now you can connect viewer to the livestream as described in our [React Native] and [React] docs.
+Now you can connect the viewer to the livestream as described in our [React Native] and [React] docs.
 
 :::info
 Viewers connect using [WHEP](https://blog.swmansion.com/introducing-react-native-whip-whep-ac9e5588d4da) standard, allowing the use of any player that supports the WHEP standard.


### PR DESCRIPTION
## Description

# Closes FCE-1488

Adds server-side livestreaming documentation. 

Things worth doing before merging this PR:
* rename room type: broadcast -> livestream in server SDKs 
* rename `createBroadcastViewerToken` to `createLivestreamViewerToken` in `js-server-sdk`
* add client-side docs and link them correctly in server-side docs
