### PR TITLE
Bump sdks and versioning fixes

### DIFF
--- a/docs/explanation/architecture.mdx
+++ b/docs/explanation/architecture.mdx
@@ -81,11 +81,11 @@ sequenceDiagram
 
 ## Next Steps
 
-To understand different room types in detail, see [Room Types Explained](/explanation/room-types).
+To understand different room types in detail, see [Room Types Explained](../explanation/room-types).
 
-To learn about security and token management, see [Security & Token Model](/explanation/security-tokens).
+To learn about security and token management, see [Security & Token Model](../explanation/security-tokens).
 
 Ready to implement? Start with our tutorials:
 
-- [React Native Quick Start](/tutorials/react-native-quick-start)
-- [Backend Quick Start](/tutorials/backend-quick-start)
+- [React Native Quick Start](../tutorials/react-native-quick-start)
+- [Backend Quick Start](../tutorials/backend-quick-start)

--- a/docs/explanation/public-livestreams.mdx
+++ b/docs/explanation/public-livestreams.mdx
@@ -65,7 +65,7 @@ This aims to provide control over who can view a livestream, but requires you to
 ### Creating a viewer token
 
 Below we show how you would create a livestream viewer token in a production scenario, with your own backend.
-Note that for development purposes, you can [use the Sandbox API to generate a viewer token](/tutorials/livestreaming#obtaining-a-token-1).
+Note that for development purposes, you can [use the Sandbox API to generate a viewer token](../tutorials/livestreaming#obtaining-a-token-1).
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -108,7 +108,7 @@ Note that for development purposes, you can [use the Sandbox API to generate a v
 
 ### Connecting to a private room
 
-Once you've created a viewer token, you can connect to a room using the Fishjam client SDKs (examples below), or alternatively you can use [WHEP](/how-to/features/whip-whep#private-livestreams).
+Once you've created a viewer token, you can connect to a room using the Fishjam client SDKs (examples below), or alternatively you can use [WHEP](../how-to/features/whip-whep#private-livestreams).
 
 <Tabs groupId="platform">
   <TabItem value="react" label="React">
@@ -172,7 +172,7 @@ Such an application will benefit from the token-based authorization in [private 
 
 ### Connecting to a public room
 
-Once you've created a room of type `livestream` with the `public` flag enabled, you may start connecting viewers to the stream via the Fishjam client SDKs or [WHEP](/how-to/features/whip-whep#public-livestreams).
+Once you've created a room of type `livestream` with the `public` flag enabled, you may start connecting viewers to the stream via the Fishjam client SDKs or [WHEP](../how-to/features/whip-whep#public-livestreams).
 
 <Tabs groupId="platform">
   <TabItem value="react" label="React">

--- a/docs/explanation/room-types.mdx
+++ b/docs/explanation/room-types.mdx
@@ -116,15 +116,15 @@ Livestream rooms are **20% cheaper** than conference rooms for equivalent usage.
 
 To understand how to use each room type:
 
-- [How to implement livestreaming](/tutorials/livestreaming)
-- [How to create audio-only calls](/how-to/features/audio-only-calls)
+- [How to implement livestreaming](../tutorials/livestreaming)
+- [How to create audio-only calls](../how-to/features/audio-only-calls)
 
 To learn about the underlying architecture:
 
-- [Fishjam Architecture](/explanation/architecture)
-- [Security & Token Model](/explanation/security-tokens)
+- [Fishjam Architecture](../explanation/architecture)
+- [Security & Token Model](../explanation/security-tokens)
 
 Ready to start building? Check our tutorials:
 
-- [React Native Quick Start](/tutorials/react-native-quick-start)
-- [Backend Quick Start](/tutorials/backend-quick-start)
+- [React Native Quick Start](../tutorials/react-native-quick-start)
+- [Backend Quick Start](../tutorials/backend-quick-start)

--- a/docs/explanation/sandbox-api-concept.mdx
+++ b/docs/explanation/sandbox-api-concept.mdx
@@ -69,13 +69,13 @@ This shows you exactly what your production backend needs to do, just with prope
 
 To understand how to use The Sandbox API for development:
 
-- [How to use The Sandbox API for testing](/how-to/features/sandbox-api-testing)
+- [How to use The Sandbox API for testing](../how-to/features/sandbox-api-testing)
 
 To learn about building your own backend:
 
-- [Backend Quick Start Tutorial](/tutorials/backend-quick-start)
-- [How to set up your server](/how-to/backend/server-setup)
+- [Backend Quick Start Tutorial](../tutorials/backend-quick-start)
+- [How to set up your server](../how-to/backend/server-setup)
 
 To understand the security model:
 
-- [Security & Token Model](/explanation/security-tokens)
+- [Security & Token Model](../explanation/security-tokens)

--- a/docs/explanation/security-tokens.mdx
+++ b/docs/explanation/security-tokens.mdx
@@ -36,8 +36,8 @@ Management tokens provide your backend server with administrative access to Fish
 Management tokens give permission to:
 
 - Create and manage rooms and peers
-- Setup [webhooks](/how-to/backend/server-setup#webhooks)
-- Set [immutable peer metadata](/how-to/backend/server-setup#metadata)
+- Setup [webhooks](../how-to/backend/server-setup#webhooks)
+- Set [immutable peer metadata](../how-to/backend/server-setup#metadata)
 
 ## Peer Tokens
 
@@ -110,13 +110,13 @@ await joinRoom({
 
 To implement secure authentication:
 
-- [Backend Quick Start Tutorial](/tutorials/backend-quick-start)
-- [How to set up your server](/how-to/backend/server-setup)
+- [Backend Quick Start Tutorial](../tutorials/backend-quick-start)
+- [How to set up your server](../how-to/backend/server-setup)
 
 To understand the broader architecture:
 
-- [Fishjam Architecture](/explanation/architecture)
+- [Fishjam Architecture](../explanation/architecture)
 
 To learn about the Sandbox API's security limitations:
 
-- [Understanding the Sandbox API](/explanation/sandbox-api-concept)
+- [Understanding the Sandbox API](../explanation/sandbox-api-concept)

--- a/docs/explanation/what-is-fishjam.mdx
+++ b/docs/explanation/what-is-fishjam.mdx
@@ -56,12 +56,12 @@ Create voice-only experiences like audio conferencing, podcasts, or voice chat a
 
 ## Next Steps
 
-To understand how Fishjam works technically, see [Fishjam Architecture](/explanation/architecture).
+To understand how Fishjam works technically, see [Fishjam Architecture](../explanation/architecture).
 
-To learn about the different types of rooms available, see [Room Types Explained](/explanation/room-types).
+To learn about the different types of rooms available, see [Room Types Explained](../explanation/room-types).
 
 Ready to start building? Check out our tutorials:
 
-- [React Native Quick Start](/tutorials/react-native-quick-start)
-- [React Quick Start](/tutorials/react-quick-start)
-- [Backend Quick Start](/tutorials/backend-quick-start)
+- [React Native Quick Start](../tutorials/react-native-quick-start)
+- [React Quick Start](../tutorials/react-quick-start)
+- [Backend Quick Start](../tutorials/backend-quick-start)

--- a/docs/how-to/_common/metadata/header.mdx
+++ b/docs/how-to/_common/metadata/header.mdx
@@ -4,7 +4,7 @@ However, it can be also used to send the peer's camera type, application informa
 
 :::info
 
-You can also set metadata on [the server side, when adding user to the room](/how-to/backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
+You can also set metadata on [the server side, when adding user to the room](../../../how-to/backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
 can't be overwritten by the peer, like information about real user names or basic permission info.
 
 :::

--- a/docs/how-to/_common/metadata/reading.mdx
+++ b/docs/how-to/_common/metadata/reading.mdx
@@ -4,6 +4,6 @@ Peer metadata is available as the `metadata` property for each peer. Therefore, 
 the metadata associated with them.
 Note that the `metadata.peer` property contains only the metadata set by the client SDK (as in the examples examples above).
 The metadata set on the server side is available as `metadata.server`.
-Learn more about server metadata [here](/how-to/backend/server-setup#metadata).
+Learn more about server metadata [here](../../../how-to/backend/server-setup#metadata).
 
 {props.children}

--- a/docs/how-to/_common/metadata/reading.mdx
+++ b/docs/how-to/_common/metadata/reading.mdx
@@ -4,6 +4,6 @@ Peer metadata is available as the `metadata` property for each peer. Therefore, 
 the metadata associated with them.
 Note that the `metadata.peer` property contains only the metadata set by the client SDK (as in the examples examples above).
 The metadata set on the server side is available as `metadata.server`.
-Learn more about server metadata [here](../../../how-to/backend/server-setup#metadata).
+Learn more about server metadata [here](../backend/server-setup#metadata).
 
 {props.children}

--- a/docs/how-to/backend/fastapi-example.mdx
+++ b/docs/how-to/backend/fastapi-example.mdx
@@ -6,7 +6,7 @@ title: FastAPI
 # FastAPI example
 
 The example assumes you've already installed [**our SDK**](https://github.com/fishjam-cloud/python-server-sdk) and you're ready to go.  
-If you wish to see more general info, visit [**Set up your server**](/how-to/backend/server-setup) article.
+If you wish to see more general info, visit [**Set up your server**](../../how-to/backend/server-setup) article.
 
 ## Minimal setup
 

--- a/docs/how-to/backend/fastify-example.mdx
+++ b/docs/how-to/backend/fastify-example.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 # Fastify example
 
 The example assumes you've already installed [**our SDK**](https://www.npmjs.com/package/@fishjam-cloud/js-server-sdk) and you're ready to go.  
-If you wish to see more general info, visit [**set up your server**](/how-to/backend/server-setup) article.
+If you wish to see more general info, visit [**set up your server**](../../how-to/backend/server-setup) article.
 
 ## Load environment variables to Fastify
 
@@ -121,7 +121,7 @@ Then, you will be able to access the parsed message at `request.Body`.
 
 ```ts title='main.ts'
 import Fastify, { FastifyRequest } from "fastify";
-import { ServerMessage } from "@fishjam-cloud/js-server-sdk/proto";
+import { ServerMessage } from "@fishjam-cloud/js-server-sdk";
 
 const fastify = Fastify();
 
@@ -229,8 +229,8 @@ const fishjamNotifierPlugin = fastifyPlugin((fastify) => {
   const fishjamNotifier = new FishjamWSNotifier(
     { fishjamUrl: "aaa", managementToken: "bbb" },
     (err) => fastify.log.error(err),
-    () => fastify.log.info("Websocket connection to Fishjam closed"),
-    () => fastify.log.error("Failed to connect Fishjam notifier"),
+    (_code, _reason) =>
+      fastify.log.info("Websocket connection to Fishjam closed"),
   );
 });
 

--- a/docs/how-to/backend/production-deployment.mdx
+++ b/docs/how-to/backend/production-deployment.mdx
@@ -13,7 +13,7 @@ This guide covers the essential steps to move from development (using the Sandbo
 
 ## Prerequisites
 
-- Working Fishjam backend (see [Backend Quick Start](/tutorials/backend-quick-start))
+- Working Fishjam backend (see [Backend Quick Start](../../tutorials/backend-quick-start))
 - Production Fishjam environment (not Sandbox)
 - Domain and SSL certificates for your backend
 - Production database and infrastructure
@@ -291,10 +291,10 @@ However, if you wish to reuse a single peer over multiple days, you can make use
 
 For scaling considerations:
 
-- [Understanding Fishjam Architecture](/explanation/architecture)
-- [Security best practices](/explanation/security-tokens)
+- [Understanding Fishjam Architecture](../../explanation/architecture)
+- [Security best practices](../../explanation/security-tokens)
 
 For specific backend frameworks:
 
-- [FastAPI example](/how-to/backend/fastapi-example)
-- [Fastify example](/how-to/backend/fastify-example)
+- [FastAPI example](../../how-to/backend/fastapi-example)
+- [Fastify example](../../how-to/backend/fastify-example)

--- a/docs/how-to/backend/server-setup.mdx
+++ b/docs/how-to/backend/server-setup.mdx
@@ -164,8 +164,8 @@ At any time you can terminate user's access by deleting the peer.
 
 #### Metadata
 
-When creating a peer, you can also assign metadata to that peer, which can be read later with the [mobile SDK](/how-to/react-native/metadata-and-broadcasting)
-or [web SDK](/how-to/react/metadata). This metadata can be only set when creating the peer and can't be updated later.
+When creating a peer, you can also assign metadata to that peer, which can be read later with the [mobile SDK](../../how-to/react-native/metadata-and-broadcasting)
+or [web SDK](../../how-to/react/metadata). This metadata can be only set when creating the peer and can't be updated later.
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">

--- a/docs/how-to/features/audio-only-calls.mdx
+++ b/docs/how-to/features/audio-only-calls.mdx
@@ -22,7 +22,7 @@ If the same room were audio-only, then the final cost of the room will only be e
 
 ## How Do I Use It?
 
-Using this feature is as easy as setting the `roomType` field to `audio_only` when creating a room using our [Server SDKs](/how-to/backend/server-setup)
+Using this feature is as easy as setting the `roomType` field to `audio_only` when creating a room using our [Server SDKs](../../how-to/backend/server-setup)
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -49,7 +49,7 @@ Using this feature is as easy as setting the `roomType` field to `audio_only` wh
   </TabItem>
  </Tabs>
 
-Now, you can connect peers normally to the room as described in our [React Native](/how-to/react-native/connecting) and [React](/how-to/react/connecting) docs.
+Now, you can connect peers normally to the room as described in our [React Native](../../how-to/react-native/connecting) and [React](../../how-to/react/connecting) docs.
 
 :::info
 The React Native and React SDKs will log a warning in the console if any attempt to add video to an audio-only room is made.

--- a/docs/how-to/features/sandbox-api-testing.mdx
+++ b/docs/how-to/features/sandbox-api-testing.mdx
@@ -313,11 +313,11 @@ This will invalidate all existing tokens (including the management token!) and g
 
 Once you've tested your integration with the Sandbox API:
 
-- [Set up your own backend](/tutorials/backend-quick-start)
-- [Learn more about the Sandbox API](/explanation/sandbox-api-concept)
-- [Understand security implications](/explanation/security-tokens)
+- [Set up your own backend](../../tutorials/backend-quick-start)
+- [Learn more about the Sandbox API](../../explanation/sandbox-api-concept)
+- [Understand security implications](../../explanation/security-tokens)
 
 For production deployment:
 
-- [How to set up a production server](/how-to/backend/server-setup)
-- [How to implement proper authentication](/explanation/security-tokens)
+- [How to set up a production server](../../how-to/backend/server-setup)
+- [How to implement proper authentication](../../explanation/security-tokens)

--- a/docs/how-to/features/whip-whep.mdx
+++ b/docs/how-to/features/whip-whep.mdx
@@ -9,10 +9,10 @@ import TabItem from "@theme/TabItem";
 # Livestreaming using WHIP/WHEP
 
 :::tip
-Make sure to read [Livestreaming with Fishjam](/tutorials/livestreaming) before reading this guide.
+Make sure to read [Livestreaming with Fishjam](../../tutorials/livestreaming) before reading this guide.
 This guide focuses on a low-level way to communicate with Fishjam.
 
-The majority of use-cases should prefer to use the methods described in [Livestreaming with Fishjam](/tutorials/livestreaming).
+The majority of use-cases should prefer to use the methods described in [Livestreaming with Fishjam](../../tutorials/livestreaming).
 :::
 
 If you've reading this guide, it is more than likely that you've already heard of **WHIP** (WebRTC HTTP Ingress Protocol) and **WHEP** (WebRTC HTTP Egress Protocol).
@@ -44,7 +44,7 @@ You can paste this URL in your WHIP client of choice to start streaming.
 ### Getting the token
 
 To authenticate a streamer, you need to first create a room of type `livestream` and a streamer token for that room.
-You can read about this in detail in [Production Livestreaming with Server SDKs](/tutorials/livestreaming#production-livestreaming-with-server-sdks), but the TL;DR is
+You can read about this in detail in [Production Livestreaming with Server SDKs](../../tutorials/livestreaming#production-livestreaming-with-server-sdks), but the TL;DR is
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -102,7 +102,7 @@ The usage of WHEP is very similar to WHIP, as you need the following:
 With Fishjam, if the livestream is private, then the **token is required**.
 On the other hand, if the livestream is public, then the **token is omitted**.
 
-[Private vs Public Livestreams](/explanation/public-livestreams) explains private and public livestreams in more detail.
+[Private vs Public Livestreams](../../explanation/public-livestreams) explains private and public livestreams in more detail.
 In this guide we demonstrate how to view each livestream type using WHEP directly.
 
 ### Private livestreams
@@ -120,7 +120,7 @@ You can paste this URL in your WHEP client of choice to start viewing.
 #### Getting the token
 
 To authenticate a viewer, you need to create a viewer token for a room of `livestream` type.
-You can read about this in detail in [Production Livestreaming with Server SDKs](/tutorials/livestreaming#production-livestreaming-with-server-sdks), but the TL;DR is
+You can read about this in detail in [Production Livestreaming with Server SDKs](../../tutorials/livestreaming#production-livestreaming-with-server-sdks), but the TL;DR is
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -217,12 +217,12 @@ http://fishjam.io/api/v1/live/api/whep/[ROOM-ID]
 
 More on livestreaming:
 
-- [Livestreaming tutorial](/tutorials/livestreaming)
-- [Private vs Public livestreams](/explanation/public-livestreams)
+- [Livestreaming tutorial](../../tutorials/livestreaming)
+- [Private vs Public livestreams](../../explanation/public-livestreams)
 
 If livestreaming doesn't fit your use case:
 
-- [Room types explained](/explanation/room-types)
-- [Videoconferencing in React Native](/tutorials/react-native-quick-start)
-- [Videoconferencing in React](/tutorials/react-quick-start)
-- [Audio-only calls](/how-to/features/audio-only-calls)
+- [Room types explained](../../explanation/room-types)
+- [Videoconferencing in React Native](../../tutorials/react-native-quick-start)
+- [Videoconferencing in React](../../tutorials/react-quick-start)
+- [Audio-only calls](../../how-to/features/audio-only-calls)

--- a/docs/how-to/react-native/background-streaming.mdx
+++ b/docs/how-to/react-native/background-streaming.mdx
@@ -61,12 +61,12 @@ You need to modify `AndroidManifest.xml` file and add below service:
 
   <TabItem value="android" label="Android">
 
-You can use [`useForegroundService`](/api/mobile/variables/useForegroundService) hook to handle how foreground service behaves on Android.
+You can use [`useForegroundService`](../../api/mobile/variables/useForegroundService) hook to handle how foreground service behaves on Android.
 
 :::important[Permissions]
 
-If you want to use [`enableCamera`](/api/mobile/type-aliases/ForegroundServiceConfig#enablecamera) or [`enableMicrophone`](/api/mobile/type-aliases/ForegroundServiceConfig#enablemicrophone),
-user must first grant permission for this resource. [`useForegroundService`](/api/mobile/variables/useForegroundService) will check if permission is
+If you want to use [`enableCamera`](../../api/mobile/type-aliases/ForegroundServiceConfig#enablecamera) or [`enableMicrophone`](../../api/mobile/type-aliases/ForegroundServiceConfig#enablemicrophone),
+user must first grant permission for this resource. [`useForegroundService`](../../api/mobile/variables/useForegroundService) will check if permission is
 granted and only then allow to start a service.
 
 :::

--- a/docs/how-to/react-native/connecting.mdx
+++ b/docs/how-to/react-native/connecting.mdx
@@ -19,7 +19,7 @@ your Room).
   <TabItem value="sandbox" label="Sandbox App">
 
 Once you create your account on [Fishjam](https://fishjam.io), you will have access to the Sandbox environment as part of the Mini Jar plan.
-While using the Sandbox environment, [you can use the Sandbox API](/how-to/features/sandbox-api-testing) to generate peer tokens for testing or development purposes.
+While using the Sandbox environment, [you can use the Sandbox API](../../how-to/features/sandbox-api-testing) to generate peer tokens for testing or development purposes.
 This is basically a service that will create a Room, add your app as
 the Room's Peer, and return the token required to use that Room.
 
@@ -39,14 +39,14 @@ const peerToken = await getSandboxPeerToken(roomName, peerName);
   <TabItem value="production" label="Production App">
 
 For the production app, you need to implement your own backend service that will provide the user with a **Peer Token**. To do that,
-follow our [server setup instructions](/how-to/backend/server-setup).
+follow our [server setup instructions](../../how-to/backend/server-setup).
 
   </TabItem>
 </Tabs>
 
 ## Connecting
 
-In order to connect, call [`joinRoom`](/api/mobile/functions/useConnection#joinroom) method with the `peerToken` and the fishjam ID:
+In order to connect, call [`joinRoom`](../../api/mobile/functions/useConnection#joinroom) method with the `peerToken` and the fishjam ID:
 
 ```tsx
 import React, { useCallback } from "react";
@@ -73,7 +73,7 @@ export function JoinRoomButton() {
 
 ## Disconnecting
 
-In order to close the connection, you have to call [`leaveRoom`](/api/mobile/functions/useConnection#leaveroom) method.
+In order to close the connection, you have to call [`leaveRoom`](../../api/mobile/functions/useConnection#leaveroom) method.
 
 ```tsx
 import React, { useCallback } from "react";

--- a/docs/how-to/react-native/custom-video-sources/index.mdx
+++ b/docs/how-to/react-native/custom-video-sources/index.mdx
@@ -10,5 +10,5 @@ This section contains guides for implementing custom video sources in the Fishja
 
 ## Available Guides
 
-- [Custom Source](/how-to/react-native/custom-video-sources/overview) - Learn how to create a basic custom video source
-- [Vision Camera](/how-to/react-native/custom-video-sources/vision-camera) - Learn how to implement Vision Camera as a custom video source
+- [Custom Source](../../../how-to/react-native/custom-video-sources/overview) - Learn how to create a basic custom video source
+- [Vision Camera](../../../how-to/react-native/custom-video-sources/vision-camera) - Learn how to implement Vision Camera as a custom video source

--- a/docs/how-to/react-native/list-other-peers.mdx
+++ b/docs/how-to/react-native/list-other-peers.mdx
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # List other peers
 
-In order to see other streaming peers, you can use [`usePeers`](/api/mobile/functions/usePeers). It will return all  
+In order to see other streaming peers, you can use [`usePeers`](../../api/mobile/functions/usePeers). It will return all  
 other peers, together with the tracks that they are streaming.
 
 ### Example code that show all videos

--- a/docs/how-to/react-native/reconnection-handling.mdx
+++ b/docs/how-to/react-native/reconnection-handling.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 # Reconnect
 
 If your connection is lost while you are connected to a room, the app will automatically handle the reconnection process.
-You can monitor these events by utilizing the [`useConnection`](/api/mobile/functions/useConnection) hook.
+You can monitor these events by utilizing the [`useConnection`](../../api/mobile/functions/useConnection) hook.
 
 ### Example hook that logs the current status to the console
 

--- a/docs/how-to/react-native/screensharing.mdx
+++ b/docs/how-to/react-native/screensharing.mdx
@@ -152,11 +152,11 @@ Configuring screen sharing on iOS is a little complicated.
 
 ## Usage
 
-You can use [`useScreenShare`](/api/mobile/functions/useScreenShare) hook to enable screen sharing.
+You can use [`useScreenShare`](../../api/mobile/functions/useScreenShare) hook to enable screen sharing.
 
 :::tip[Permissions]
 
-Permission request is handled for you as soon as you call [`toggleScreenShare`](/api/mobile/functions/useScreenShare#togglescreenshare).
+Permission request is handled for you as soon as you call [`toggleScreenShare`](../../api/mobile/functions/useScreenShare#togglescreenshare).
 
 :::
 
@@ -166,8 +166,8 @@ On Android API level >= 24, you must use a foreground service when screen sharin
 
 :::
 
-You can enable/disable screen sharing with [`toggleScreenShare`](/api/mobile/functions/useScreenShare#togglescreenshare) method.
-And check current state with [`isScreenShareOn`](/api/mobile/functions/useScreenShare#isscreenshareon) property.
+You can enable/disable screen sharing with [`toggleScreenShare`](../../api/mobile/functions/useScreenShare#togglescreenshare) method.
+And check current state with [`isScreenShareOn`](../../api/mobile/functions/useScreenShare#isscreenshareon) property.
 
 ```tsx
 import React, { useCallback } from "react";

--- a/docs/how-to/react-native/start-streaming.mdx
+++ b/docs/how-to/react-native/start-streaming.mdx
@@ -16,8 +16,8 @@ enabled camera and microphone will start streaming to Room.
 
 ## Enable your camera
 
-First, you have to enable your camera by calling [`prepareCamera`](/api/mobile/functions/useCamera#preparecamera) method.
-You can open show camera preview with [`VideoPreviewView`](/api/mobile/variables/VideoPreviewView) component
+First, you have to enable your camera by calling [`prepareCamera`](../../api/mobile/functions/useCamera#preparecamera) method.
+You can open show camera preview with [`VideoPreviewView`](../../api/mobile/variables/VideoPreviewView) component
 
 ```tsx
 import React, { useEffect } from "react";
@@ -39,10 +39,10 @@ export function ViewPreview() {
 
 ### Listing user cameras
 
-To list all cameras available on device, you can use [`cameras`](/api/mobile/functions/useCamera#cameras) property from [`useCamera`](/api/mobile/functions/useCamera) hook.
+To list all cameras available on device, you can use [`cameras`](../../api/mobile/functions/useCamera#cameras) property from [`useCamera`](../../api/mobile/functions/useCamera) hook.
 This way, you can either automatically choose camera (front/back) or allow user to select camera type.
 
-To change camera, simply call [`switchCamera`](/api/mobile/functions/useCamera#switchcamera) method.
+To change camera, simply call [`switchCamera`](../../api/mobile/functions/useCamera#switchcamera) method.
 
 ```tsx
 import React, { useCallback } from "react";
@@ -68,7 +68,7 @@ export function FlipButton() {
 
 ### Disabling/enabling camera
 
-To change camera state, you use [`toggleCamera`](/api/mobile/functions/useCamera#togglecamera) method.
+To change camera state, you use [`toggleCamera`](../../api/mobile/functions/useCamera#togglecamera) method.
 
 ```tsx
 import { Button } from "react-native";
@@ -89,7 +89,7 @@ export function ToggleCameraButton() {
 
 ## Enable microphone
 
-Microphone works similar to camera. In order to enable it, you have to call [`toggleMicrophone`](/api/mobile/functions/useMicrophone#togglemicrophone) method.
+Microphone works similar to camera. In order to enable it, you have to call [`toggleMicrophone`](../../api/mobile/functions/useMicrophone#togglemicrophone) method.
 
 ```tsx
 import { Button } from "react-native";

--- a/docs/how-to/react/_common/metadata/header.mdx
+++ b/docs/how-to/react/_common/metadata/header.mdx
@@ -4,7 +4,7 @@ However, it can be also used to send the peer's camera type, application informa
 
 :::info
 
-You can also set metadata on [the server side, when adding user to the room](/how-to/backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
+You can also set metadata on [the server side, when adding user to the room](../backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
 can't be overwritten by the peer, like information about real user names or basic permission info.
 
 :::

--- a/docs/how-to/react/_common/metadata/reading.mdx
+++ b/docs/how-to/react/_common/metadata/reading.mdx
@@ -4,6 +4,6 @@ Peer metadata is available as the `metadata` property for each peer. Therefore, 
 the metadata associated with them.
 Note that the `metadata.peer` property contains only the metadata set by the client SDK (as in the examples examples above).
 The metadata set on the server side is available as `metadata.server`.
-Learn more about server metadata [here](/how-to/backend/server-setup#metadata).
+Learn more about server metadata [here](../backend/server-setup#metadata).
 
 {props.children}

--- a/docs/how-to/react/connecting.mdx
+++ b/docs/how-to/react/connecting.mdx
@@ -7,12 +7,12 @@ sidebar_position: 2
 ## Prerequisites
 
 In order to connect, you need to obtain a **Peer Token** to authorize the peer in your room.
-You can get the token using the [Sandbox API](/how-to/features/sandbox-api-testing) if you're using the Sandbox environment, or implement your own backend service that will provide the user with a **Peer Token**.
+You can get the token using the [Sandbox API](../../how-to/features/sandbox-api-testing) if you're using the Sandbox environment, or implement your own backend service that will provide the user with a **Peer Token**.
 
 ## Connecting
 
-Use the [`useConnection`](/api/web/functions/useConnection) hook to get
-the [`joinRoom`](/api/web/functions/useConnection#joinroom) function.
+Use the [`useConnection`](../../api/web/functions/useConnection) hook to get
+the [`joinRoom`](../../api/web/functions/useConnection#joinroom) function.
 
 ```tsx
 const PEER_TOKEN = "some-peer-token";
@@ -37,8 +37,8 @@ export function JoinRoomButton() {
 
 ## Disconnecting
 
-In order to close connection, use the [`leaveRoom`](/api/web/functions/useConnection#leaveroom) method
-from [`useConnection`](/api/web/functions/useConnection) hook.
+In order to close connection, use the [`leaveRoom`](../../api/web/functions/useConnection#leaveroom) method
+from [`useConnection`](../../api/web/functions/useConnection) hook.
 
 ```tsx
 import { useConnection } from "@fishjam-cloud/react-client";

--- a/docs/how-to/react/custom-sources.mdx
+++ b/docs/how-to/react/custom-sources.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 :::important
 
-If you only wish to send camera, microphone or screen share output through Fishjam, then you most likely should refer to the documentation in [Streaming media](/how-to/react/start-streaming) and [Managing devices](/how-to/react/managing-devices) instead of this page.
+If you only wish to send camera, microphone or screen share output through Fishjam, then you most likely should refer to the documentation in [Streaming media](../../how-to/react/start-streaming) and [Managing devices](../../how-to/react/managing-devices) instead of this page.
 
 :::
 
@@ -17,12 +17,12 @@ This section demonstrates how to stream non-standard video or audio to other pee
 The utilities in this section allow you to integrate Fishjam with powerful browser APIs such as [WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API) and [WebGPU](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API),
 or higher level libraries, which leverage these APIs, such as [Three.js](https://threejs.org/), [Smelter](https://smelter.dev) or [PixiJS](https://pixijs.com/)
 
-## Creating a custom source - [`useCustomSource()`](/api/web/functions/useCustomSource)
+## Creating a custom source - [`useCustomSource()`](../../api/web/functions/useCustomSource)
 
 To create a custom source, you only need to do two things:
 
 1. Call the `useCustomSource` hook.
-2. Call the [`setStream`](/api/web/functions/useCustomSource#setstream) callback provided by the `useCustomSource` hook with a [MediaStream](#how-to-get-a-mediastream-object) object.
+2. Call the [`setStream`](../../api/web/functions/useCustomSource#setstream) callback provided by the `useCustomSource` hook with a [MediaStream](#how-to-get-a-mediastream-object) object.
 
 #### Usage Example
 
@@ -40,12 +40,12 @@ useEffect(() => {
 
 ### Using a created custom source
 
-Once you have called [`setStream`](/api/web/functions/useCustomSource#setstream) for a given source ID (in the above example, `"my-custom-source"`), any subsequent calls to `useCustomSource` with the same ID will return the same state.
+Once you have called [`setStream`](../../api/web/functions/useCustomSource#setstream) for a given source ID (in the above example, `"my-custom-source"`), any subsequent calls to `useCustomSource` with the same ID will return the same state.
 This enables multiple components to control and read a shared custom source.
 
 ### Deleting a custom source
 
-If you wish to remove a custom source, then you should call the [`setStream`](/api/web/functions/useCustomSource#setstream) callback with `null` as its argument.
+If you wish to remove a custom source, then you should call the [`setStream`](../../api/web/functions/useCustomSource#setstream) callback with `null` as its argument.
 
 #### Usage Example
 

--- a/docs/how-to/react/installation.mdx
+++ b/docs/how-to/react/installation.mdx
@@ -15,7 +15,7 @@ npm install @fishjam-cloud/react-client
 
 ## 2. Setup Fishjam context
 
-Wrap your app in our [`FishjamProvider`](/api/web/functions/FishjamProvider) component. Get your Fishjam ID from [Fishjam Dashboard](https://fishjam.io/app) and pass it to the provider.
+Wrap your app in our [`FishjamProvider`](../../api/web/functions/FishjamProvider) component. Get your Fishjam ID from [Fishjam Dashboard](https://fishjam.io/app) and pass it to the provider.
 
 ```tsx
 const App = () => {
@@ -44,6 +44,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 :::tip
 
 It's possible to have many independent Fishjam contexts in one app.  
-Just render many [`FishjamProvider`](/api/web/functions/FishjamProvider) components and make sure they don't overlap.
+Just render many [`FishjamProvider`](../../api/web/functions/FishjamProvider) components and make sure they don't overlap.
 
 :::

--- a/docs/how-to/react/list-other-peers.mdx
+++ b/docs/how-to/react/list-other-peers.mdx
@@ -4,8 +4,8 @@ sidebar_position: 5
 
 # Display media of other peers
 
-To access data and media of other peers, use the [`usePeers`](/api/web/functions/usePeers) hook.
-It returns two properties, [`remotePeers`](/api/web/functions/usePeers) and [`localPeer`](/api/web/functions/usePeers).
+To access data and media of other peers, use the [`usePeers`](../../api/web/functions/usePeers) hook.
+It returns two properties, [`remotePeers`](../../api/web/functions/usePeers) and [`localPeer`](../../api/web/functions/usePeers).
 They contain all the tracks of other peers and all the tracks of the local user, respectively.
 
 ### Example of playing other peers' available media

--- a/docs/how-to/react/managing-devices.mdx
+++ b/docs/how-to/react/managing-devices.mdx
@@ -6,10 +6,10 @@ sidebar_position: 4
 
 The Fishjam SDK provides functions for dynamically controlling media device streams. This includes selecting desired cameras and microphones, turning them on and off, as well as muting and unmuting microphones.
 
-### Selecting Camera and Microphone - [`selectCamera()`](/api/web/functions/useCamera#selectcamera) and [`selectMicrophone()`](/api/web/functions/useMicrophone#selectmicrophone)
+### Selecting Camera and Microphone - [`selectCamera()`](../../api/web/functions/useCamera#selectcamera) and [`selectMicrophone()`](../../api/web/functions/useMicrophone#selectmicrophone)
 
-To select the desired camera or microphone, use the [`selectCamera()`](/api/web/functions/useCamera#selectcamera) and [`selectMicrophone()`](/api/web/functions/useMicrophone#selectmicrophone) functions.  
-Lists of the available devices are available via the [`cameraDevices`](/api/web/functions/useCamera#cameradevices) and [`microphoneDevices`](/api/web/functions/useMicrophone#microphonedevices) properties.
+To select the desired camera or microphone, use the [`selectCamera()`](../../api/web/functions/useCamera#selectcamera) and [`selectMicrophone()`](../../api/web/functions/useMicrophone#selectmicrophone) functions.  
+Lists of the available devices are available via the [`cameraDevices`](../../api/web/functions/useCamera#cameradevices) and [`microphoneDevices`](../../api/web/functions/useMicrophone#microphonedevices) properties.
 
 #### Usage Example
 
@@ -32,7 +32,7 @@ export function CameraControl() {
 }
 ```
 
-### Turning Camera On and Off - [`toggleCamera()`](/api/web/functions/useCamera#togglecamera)
+### Turning Camera On and Off - [`toggleCamera()`](../../api/web/functions/useCamera#togglecamera)
 
 This function controls the physical operational state of the camera.
 
@@ -52,14 +52,14 @@ export function CameraControl() {
 }
 ```
 
-### Turning Microphone On and Off - [`toggleMicrophone()`](/api/web/functions/useMicrophone#togglemicrophone)
+### Turning Microphone On and Off - [`toggleMicrophone()`](../../api/web/functions/useMicrophone#togglemicrophone)
 
 This function toggles the microphone's physical operational state. The function interacts with a physical device, so it might take a noticeable amount of time.
 
 - **Turning the microphone off**: Turns the microphone off, disables the media stream, and pauses any audio transmission.
 - **Turning the microphone on**: Turns the microphone on and resumes audio streaming.
 
-### Muting and Unmuting Microphone - [`toggleMicrophoneMute()`](/api/web/functions/useMicrophone#togglemicrophonemute)
+### Muting and Unmuting Microphone - [`toggleMicrophoneMute()`](../../api/web/functions/useMicrophone#togglemicrophonemute)
 
 This function manages the audio stream's operational status without affecting the microphone's hardware state.
 Muting and unmuting is faster, but a muted device still uses resources. This is useful, as it is common to mute and unmute during a meeting. Unmuting needs to be quick to capture the first word of a sentence.

--- a/docs/how-to/react/start-streaming.mdx
+++ b/docs/how-to/react/start-streaming.mdx
@@ -8,13 +8,13 @@ sidebar_position: 3
 
 Fishjam provides an API to browse and manage media devices you can use.  
 To ask the browser for permission to list the available devices,
-call the [`initializeDevices`](/api/web/functions/useInitializeDevices#initializedevices)
-function from [`useInitializeDevices`](/api/web/functions/useInitializeDevices) hook.
+call the [`initializeDevices`](../../api/web/functions/useInitializeDevices#initializedevices)
+function from [`useInitializeDevices`](../../api/web/functions/useInitializeDevices) hook.
 
-You can choose whether to initialize both camera and microphone devices or just one of them by passing [`InitializeDevicesSettings`](/api/web/type-aliases/InitializeDevicesSettings)
+You can choose whether to initialize both camera and microphone devices or just one of them by passing [`InitializeDevicesSettings`](../../api/web/type-aliases/InitializeDevicesSettings)
 as an argument. By default, both camera and microphone are initialized.
 
-The [`initializeDevices`](/api/web/functions/useInitializeDevices#initializedevices) function will return a [`Promise<InitializeDevicesResult>`](/api/web/type-aliases/InitializeDevicesResult) object.
+The [`initializeDevices`](../../api/web/functions/useInitializeDevices#initializedevices) function will return a [`Promise<InitializeDevicesResult>`](../../api/web/type-aliases/InitializeDevicesResult) object.
 
 ```ts
 import React, { useEffect } from "react";
@@ -33,15 +33,15 @@ export function useExample() {
 ```
 
 :::note
-The [`useInitializeDevices`](/api/web/functions/useInitializeDevices) hook gives you the convenience of asking the user for all permissions at once.
+The [`useInitializeDevices`](../../api/web/functions/useInitializeDevices) hook gives you the convenience of asking the user for all permissions at once.
 
-It is not the only way to enable the device. You can just toggle the device using [`useCamera`](/api/web/functions/useCamera) or [`useMicrophone`](/api/web/functions/useMicrophone) hooks.
+It is not the only way to enable the device. You can just toggle the device using [`useCamera`](../../api/web/functions/useCamera) or [`useMicrophone`](../../api/web/functions/useMicrophone) hooks.
 :::
 
 ### Device API
 
-To manage users' camera and microphone devices, use the respective [`useCamera`](/api/web/functions/useCamera)
-and [`useMicrophone`](/api/web/functions/useMicrophone) hooks.
+To manage users' camera and microphone devices, use the respective [`useCamera`](../../api/web/functions/useCamera)
+and [`useMicrophone`](../../api/web/functions/useMicrophone) hooks.
 Both of them has similar API. To keep things simple, we will just use the camera hook.
 
 ```tsx

--- a/docs/how-to/react/stream-middleware.mdx
+++ b/docs/how-to/react/stream-middleware.mdx
@@ -9,7 +9,7 @@ This feature is powerful for applying effects, custom encodings, or any other tr
 
 ## Overview
 
-Define a [`TrackMiddleware`](/api/web/type-aliases/TrackMiddleware) function which takes a `MediaStreamTrack` and returns an object containing the modified `MediaStreamTrack`
+Define a [`TrackMiddleware`](../../api/web/type-aliases/TrackMiddleware) function which takes a `MediaStreamTrack` and returns an object containing the modified `MediaStreamTrack`
 and an optional `onClear` function, which is called when the middleware needs to be removed or reapplied when a device changes.
 
 ### Type definition
@@ -22,11 +22,11 @@ export type TrackMiddleware = (
 
 ### Setting middleware
 
-You can set the middleware for your media tracks using [`setTrackMiddleware`](/api/web/functions/useCamera) method. This method accepts a `TrackMiddleware` or `null` for removing previously set middleware.
+You can set the middleware for your media tracks using [`setTrackMiddleware`](../../api/web/functions/useCamera) method. This method accepts a `TrackMiddleware` or `null` for removing previously set middleware.
 
 ### Example: Applying a blur effect
 
-The following example demonstrates how to apply a custom blur effect to the camera track using the [`useCamera`](/api/web/functions/useCamera) hook and middleware.
+The following example demonstrates how to apply a custom blur effect to the camera track using the [`useCamera`](../../api/web/functions/useCamera) hook and middleware.
 
 ```tsx
 class BlurProcessor {

--- a/docs/how-to/troubleshooting/video-codecs.mdx
+++ b/docs/how-to/troubleshooting/video-codecs.mdx
@@ -19,7 +19,7 @@ Fishjam uses H.264 by default, however, to solve an issue with Android emulators
 
 ### Changing the Codec
 
-Override the default codec by setting the `codec` parameter when [creating a room](/api/server/interfaces/RoomConfig#videocodec) using server SDKs.
+Override the default codec by setting the `codec` parameter when [creating a room](../../api/server/interfaces/RoomConfig#videocodec) using server SDKs.
 
 ### Why VP8 and H.264?
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -35,10 +35,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="/tutorials/react-native-quick-start">React Native Quick Start</a></li>
-      <li><a href="/tutorials/react-quick-start">React Quick Start</a></li>
-      <li><a href="/tutorials/backend-quick-start">Backend Quick Start</a></li>
-      <li><a href="/tutorials" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href="./tutorials/react-native-quick-start">React Native Quick Start</a></li>
+      <li><a href="./tutorials/react-quick-start">React Quick Start</a></li>
+      <li><a href="./tutorials/backend-quick-start">Backend Quick Start</a></li>
+      <li><a href="./tutorials" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -62,10 +62,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="/how-to/react-native/installation">React Native Installation and Setup</a></li>
-      <li><a href="/how-to/react/installation">React Installation and Setup</a></li>
-      <li><a href="/how-to/backend/production-deployment">Backend Production Deployment</a></li>
-      <li><a href="/how-to" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href="./how-to/react-native/installation">React Native Installation and Setup</a></li>
+      <li><a href="./how-to/react/installation">React Installation and Setup</a></li>
+      <li><a href="./how-to/backend/production-deployment">Backend Production Deployment</a></li>
+      <li><a href="./how-to" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -89,10 +89,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="/explanation/what-is-fishjam">What is Fishjam?</a></li>
-      <li><a href="/explanation/architecture">Architecture Overview</a></li>
-      <li><a href="/explanation/sandbox-api-concept">Sandbox API</a></li>
-      <li><a href="/explanation" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href="./explanation/what-is-fishjam">What is Fishjam?</a></li>
+      <li><a href="./explanation/architecture">Architecture Overview</a></li>
+      <li><a href="./explanation/sandbox-api-concept">Sandbox API</a></li>
+      <li><a href="./explanation" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -116,10 +116,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="/api/mobile">React Native SDK API</a></li>
-      <li><a href="/api/web">React/Web SDK API</a></li>
-      <li><a href="/api/server">Server SDK API</a></li>
-      <li><a href="/api" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href="./api/mobile">React Native SDK API</a></li>
+      <li><a href="./api/web">React/Web SDK API</a></li>
+      <li><a href="./api/server">Server SDK API</a></li>
+      <li><a href="./api" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,6 +4,7 @@ sidebar_position: 0
 
 import QuickNavigation from "@site/src/components/QuickNavigation";
 import { items } from "@site/src/content/cardItems";
+import { useVersionedLink } from "@site/src/hooks/useVersionedLink";
 
 # Welcome to Fishjam
 
@@ -35,10 +36,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="./tutorials/react-native-quick-start">React Native Quick Start</a></li>
-      <li><a href="./tutorials/react-quick-start">React Quick Start</a></li>
-      <li><a href="./tutorials/backend-quick-start">Backend Quick Start</a></li>
-      <li><a href="./tutorials" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li>[React Native Quick Start](./tutorials/react-native-quick-start.mdx)</li>
+      <li>[React Quick Start](./tutorials/react-quick-start.mdx)</li>
+      <li>[Backend Quick Start](./tutorials/backend-quick-start.mdx)</li>
+      <li><a href={useVersionedLink("tutorials")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -65,7 +66,7 @@ To get started, we recommend you check out one of the two guides below:
       <li><a href="./how-to/react-native/installation">React Native Installation and Setup</a></li>
       <li><a href="./how-to/react/installation">React Installation and Setup</a></li>
       <li><a href="./how-to/backend/production-deployment">Backend Production Deployment</a></li>
-      <li><a href="./how-to" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href={useVersionedLink("how-to")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -92,7 +93,7 @@ To get started, we recommend you check out one of the two guides below:
       <li><a href="./explanation/what-is-fishjam">What is Fishjam?</a></li>
       <li><a href="./explanation/architecture">Architecture Overview</a></li>
       <li><a href="./explanation/sandbox-api-concept">Sandbox API</a></li>
-      <li><a href="./explanation" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href={useVersionedLink("explanation")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -119,7 +120,7 @@ To get started, we recommend you check out one of the two guides below:
       <li><a href="./api/mobile">React Native SDK API</a></li>
       <li><a href="./api/web">React/Web SDK API</a></li>
       <li><a href="./api/server">Server SDK API</a></li>
-      <li><a href="./api" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href={useVersionedLink("api")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -63,9 +63,9 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="./how-to/react-native/installation">React Native Installation and Setup</a></li>
-      <li><a href="./how-to/react/installation">React Installation and Setup</a></li>
-      <li><a href="./how-to/backend/production-deployment">Backend Production Deployment</a></li>
+      <li>[React Native Installation and Setup](./how-to/react-native/installation.mdx)</li>
+      <li>[React Installation and Setup](./how-to/react/installation.mdx)</li>
+      <li>[Backend Production Deployment](./how-to/backend/production-deployment.mdx)</li>
       <li><a href={useVersionedLink("how-to")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
@@ -90,9 +90,9 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="./explanation/what-is-fishjam">What is Fishjam?</a></li>
-      <li><a href="./explanation/architecture">Architecture Overview</a></li>
-      <li><a href="./explanation/sandbox-api-concept">Sandbox API</a></li>
+      <li>[What is Fishjam?](./explanation/what-is-fishjam.mdx)</li>
+      <li>[Architecture Overview](./explanation/architecture.mdx)</li>
+      <li>[Sandbox API](./explanation/sandbox-api-concept.mdx)</li>
       <li><a href={useVersionedLink("explanation")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
@@ -117,9 +117,9 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="./api/mobile">React Native SDK API</a></li>
-      <li><a href="./api/web">React/Web SDK API</a></li>
-      <li><a href="./api/server">Server SDK API</a></li>
+      <li>[React Native SDK API](./api/mobile/index.md)</li>
+      <li>[React SDK API](./api/web/index.md)</li>
+      <li>[Server SDK API](./api/server/index.md)</li>
       <li><a href={useVersionedLink("api")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 

--- a/docs/tutorials/backend-quick-start.mdx
+++ b/docs/tutorials/backend-quick-start.mdx
@@ -550,12 +550,12 @@ Here's a complete working backend:
 
 Now that you have a working backend, explore these guides:
 
-- [How to set up a production deployment](/how-to/backend/production-deployment)
-- [How to handle webhooks and events](/how-to/backend/server-setup)
-- [How to implement a FastAPI backend](/how-to/backend/fastapi-example)
-- [How to implement a Fastify backend](/how-to/backend/fastify-example)
+- [How to set up a production deployment](../how-to/backend/production-deployment)
+- [How to handle webhooks and events](../how-to/backend/server-setup)
+- [How to implement a FastAPI backend](../how-to/backend/fastapi-example)
+- [How to implement a Fastify backend](../how-to/backend/fastify-example)
 
 Or learn more about Fishjam concepts:
 
-- [Understanding security and tokens](/explanation/security-tokens)
-- [Room types explained](/explanation/room-types)
+- [Understanding security and tokens](../explanation/security-tokens)
+- [Room types explained](../explanation/room-types)

--- a/docs/tutorials/livestreaming.mdx
+++ b/docs/tutorials/livestreaming.mdx
@@ -1,5 +1,6 @@
 ---
 type: tutorial
+sidebar_position: 3
 title: Livestreaming
 ---
 
@@ -16,7 +17,7 @@ and how to get ready for production in [Production Livestreaming with Server SDK
 Fishjam implements two real-time streaming standards: WHIP (for publishing) and WHEP (for receiving).
 
 In this tutorial we explain how to publish and view streams with the client SDKs, which wrap these standards.
-If you prefer to use WHIP or WHEP directly, then you should read [WHIP/WHEP with Fishjam](/how-to/features/whip-whep).
+If you prefer to use WHIP or WHEP directly, then you should read [WHIP/WHEP with Fishjam](../how-to/features/whip-whep).
 :::
 
 ## Quickstart with Sandbox API
@@ -180,7 +181,7 @@ To receive the published livestream, we need one thing: a _viewer token_.
 In this guide, we've created a _private_ livestream, where viewers need a token to join.
 A livestream may also be _public_, where anyone can join if they know the livestream's room id.
 
-You can learn more about public livestreams in [Private vs Public Livestreams](/explanation/public-livestreams).
+You can learn more about public livestreams in [Private vs Public Livestreams](../explanation/public-livestreams).
 :::
 
 #### Obtaining a token
@@ -332,15 +333,15 @@ Then, you can start streaming as described in [Starting the stream](#starting-th
 
 Learn how to use WHIP/WHEP with Fishjam:
 
-- [WHIP/WHEP with Fishjam](/how-to/features/whip-whep)
+- [WHIP/WHEP with Fishjam](../how-to/features/whip-whep)
 
 If you want to get a better understanding of livestreaming with Fishjam, make sure to check out:
 
-- [Room Types Explained](/explanation/room-types)
-- [Private vs Public Livestreams](/explanation/public-livestreams)
+- [Room Types Explained](../explanation/room-types)
+- [Private vs Public Livestreams](../explanation/public-livestreams)
 
 If you have a different use case, then you should see
 
-- [React Quickstart](/tutorials/react-quick-start)
-- [React Native Quickstart](/tutorials/react-native-quick-start)
-- [Audio-only Calls](/how-to/features/audio-only-calls)
+- [React Quickstart](../tutorials/react-quick-start)
+- [React Native Quickstart](../tutorials/react-native-quick-start)
+- [Audio-only Calls](../how-to/features/audio-only-calls)

--- a/docs/tutorials/react-native-quick-start.mdx
+++ b/docs/tutorials/react-native-quick-start.mdx
@@ -196,12 +196,12 @@ export default function HomeScreen() {
 
 Now that you have a basic app working, explore these how-to guides:
 
-- [How to handle screen sharing](/how-to/react-native/screensharing)
-- [How to implement background streaming](/how-to/react-native/background-streaming)
-- [How to handle reconnections](/how-to/react-native/reconnection-handling)
-- [How to work with metadata](/how-to/react-native/metadata-and-broadcasting)
+- [How to handle screen sharing](../how-to/react-native/screensharing)
+- [How to implement background streaming](../how-to/react-native/background-streaming)
+- [How to handle reconnections](../how-to/react-native/reconnection-handling)
+- [How to work with metadata](../how-to/react-native/metadata-and-broadcasting)
 
 Or learn more about Fishjam concepts:
 
-- [Understanding Fishjam architecture](/explanation/architecture)
-- [Room types explained](/explanation/room-types)
+- [Understanding Fishjam architecture](../explanation/architecture)
+- [Room types explained](../explanation/room-types)

--- a/docs/tutorials/react-quick-start.mdx
+++ b/docs/tutorials/react-quick-start.mdx
@@ -274,12 +274,12 @@ export default function App() {
 
 Now that you have a basic app working, explore these how-to guides:
 
-- [How to manage media devices](/how-to/react/managing-devices)
-- [How to implement livestreaming](/tutorials/livestreaming)
-- [How to work with stream middleware](/how-to/react/stream-middleware)
-- [How to handle custom sources](/how-to/react/custom-sources)
+- [How to manage media devices](../how-to/react/managing-devices)
+- [How to implement livestreaming](../tutorials/livestreaming)
+- [How to work with stream middleware](../how-to/react/stream-middleware)
+- [How to handle custom sources](../how-to/react/custom-sources)
 
 Or learn more about Fishjam concepts:
 
-- [Understanding Fishjam architecture](/explanation/architecture)
-- [Room types explained](/explanation/room-types)
+- [Understanding Fishjam architecture](../explanation/architecture)
+- [Room types explained](../explanation/room-types)

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -138,7 +138,8 @@ const config: Config = {
           sidebarPath: "./sidebars/docs.ts",
           path: "docs",
           routeBasePath: "/",
-          editUrl: "https://github.com/fishjam-cloud/documentation/tree/main/",
+          editUrl: ({ versionDocsDirPath, docPath }) =>
+            `https://github.com/fishjam-cloud/documentation/tree/main/${versionDocsDirPath}/${docPath}`,
           beforeDefaultRehypePlugins: [rehypeShikiPlugin],
           remarkPlugins: [
             [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,6 +11,10 @@ import {
 } from "@shikijs/transformers";
 
 import { rendererClassic, transformerTwoslash } from "@shikijs/twoslash";
+import {
+  NormalizedSidebar,
+  SidebarItemsGeneratorVersion,
+} from "@docusaurus/plugin-content-docs/src/sidebars/types.js";
 
 const rehypeShikiPlugin = [
   rehypeShiki,
@@ -20,9 +24,9 @@ const rehypeShikiPlugin = [
     },
     langs: Object.keys(bundledLanguages) as BundledLanguage[],
     transformers: [
-      transformerTwoslash({
-        renderer: rendererClassic(),
-      }),
+      // transformerTwoslash({
+      //   renderer: rendererClassic(),
+      // }),
       transformerMetaHighlight(),
       transformerNotationDiff(),
       transformerNotationHighlight(),
@@ -31,32 +35,41 @@ const rehypeShikiPlugin = [
   } satisfies RehypeShikiOptions,
 ] satisfies MDXPlugin;
 
-function injectTypeDocSidebar(items) {
+function injectTypeDocSidebar(
+  version: SidebarItemsGeneratorVersion,
+  items: NormalizedSidebar,
+): NormalizedSidebar {
   return items.map((item) => {
-    if (item.customProps?.id === "generated-api") {
+    if (item.customProps?.id === "generated-api" && item.type === "category") {
       return {
         ...item,
         items: [
-          ...[
+          ...([
             {
               type: "category",
               label: "React Native SDK",
               link: { type: "doc", id: "api/mobile/index" },
-              items: require("./docs/api/mobile/typedoc-sidebar.cjs"),
+              items: require(
+                `${version.contentPath}/api/mobile/typedoc-sidebar.cjs`,
+              ),
             },
             {
               type: "category",
               label: "React SDK",
               link: { type: "doc", id: "api/web/index" },
-              items: require("./docs/api/web/typedoc-sidebar.cjs"),
+              items: require(
+                `${version.contentPath}/api/web/typedoc-sidebar.cjs`,
+              ),
             },
             {
               type: "category",
               label: "Server SDK for JS",
               link: { type: "doc", id: "api/server/index" },
-              items: require("./docs/api/server/typedoc-sidebar.cjs"),
+              items: require(
+                `${version.contentPath}/api/server/typedoc-sidebar.cjs`,
+              ),
             },
-          ],
+          ] as const),
           ...item.items.filter((element) => element.type == "doc"),
         ],
       };
@@ -135,6 +148,7 @@ const config: Config = {
             ...args
           }) {
             return injectTypeDocSidebar(
+              args.version,
               await defaultSidebarItemsGenerator(args),
             );
           },

--- a/src/components/QuickNavigation/index.tsx
+++ b/src/components/QuickNavigation/index.tsx
@@ -4,6 +4,7 @@ import styles from "./index.module.css";
 import clsx from "clsx";
 import { CardItem } from "@site/types";
 import React from "react";
+import { useVersionedLink } from "@site/src/hooks/useVersionedLink";
 
 export default function QuickNavigation(props: { items: CardItem[] }) {
   return (
@@ -12,7 +13,7 @@ export default function QuickNavigation(props: { items: CardItem[] }) {
         <article key={index} className="col col--6 margin-top--sm">
           <Link
             className={clsx("card padding--lg", styles.cardContainer)}
-            href={item.href}
+            href={useVersionedLink(item.href)}
           >
             <Heading
               as="h3"

--- a/src/content/cardItems.ts
+++ b/src/content/cardItems.ts
@@ -3,12 +3,12 @@ import { CardItem } from "@site/types";
 export const items: CardItem[] = [
   {
     title: "Quick setup with React Native",
-    href: "/tutorials/react-native-quick-start",
+    href: "tutorials/react-native-quick-start",
     icon: "📱",
   },
   {
     title: "Quick setup with React",
-    href: "/tutorials/react-quick-start",
+    href: "tutorials/react-quick-start",
     icon: "💻",
   },
 ];

--- a/src/hooks/useVersionedLink.ts
+++ b/src/hooks/useVersionedLink.ts
@@ -1,0 +1,12 @@
+import { PropSidebarItemLink } from "@docusaurus/plugin-content-docs";
+import { useDocsVersion } from "@docusaurus/plugin-content-docs/client";
+
+export function useVersionedLink(link: string) {
+  const {
+    docsSidebars: { docsSidebar },
+  } = useDocsVersion();
+
+  const root = (docsSidebar[0] as PropSidebarItemLink).href;
+
+  return `${root}${link}`;
+}

--- a/versioned_docs/version-0.20.0/explanation/architecture.mdx
+++ b/versioned_docs/version-0.20.0/explanation/architecture.mdx
@@ -81,11 +81,11 @@ sequenceDiagram
 
 ## Next Steps
 
-To understand different room types in detail, see [Room Types Explained](/explanation/room-types).
+To understand different room types in detail, see [Room Types Explained](../explanation/room-types).
 
-To learn about security and token management, see [Security & Token Model](/explanation/security-tokens).
+To learn about security and token management, see [Security & Token Model](../explanation/security-tokens).
 
 Ready to implement? Start with our tutorials:
 
-- [React Native Quick Start](/tutorials/react-native-quick-start)
-- [Backend Quick Start](/tutorials/backend-quick-start)
+- [React Native Quick Start](../tutorials/react-native-quick-start)
+- [Backend Quick Start](../tutorials/backend-quick-start)

--- a/versioned_docs/version-0.20.0/explanation/public-livestreams.mdx
+++ b/versioned_docs/version-0.20.0/explanation/public-livestreams.mdx
@@ -65,7 +65,7 @@ This aims to provide control over who can view a livestream, but requires you to
 ### Creating a viewer token
 
 Below we show how you would create a livestream viewer token in a production scenario, with your own backend.
-Note that for development purposes, you can [use the Sandbox API to generate a viewer token](/tutorials/livestreaming#obtaining-a-token-1).
+Note that for development purposes, you can [use the Sandbox API to generate a viewer token](../tutorials/livestreaming#obtaining-a-token-1).
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -108,7 +108,7 @@ Note that for development purposes, you can [use the Sandbox API to generate a v
 
 ### Connecting to a private room
 
-Once you've created a viewer token, you can connect to a room using the Fishjam client SDKs (examples below), or alternatively you can use [WHEP](/how-to/features/whip-whep#private-livestreams).
+Once you've created a viewer token, you can connect to a room using the Fishjam client SDKs (examples below), or alternatively you can use [WHEP](../how-to/features/whip-whep#private-livestreams).
 
 <Tabs groupId="platform">
   <TabItem value="react" label="React">
@@ -172,7 +172,7 @@ Such an application will benefit from the token-based authorization in [private 
 
 ### Connecting to a public room
 
-Once you've created a room of type `livestream` with the `public` flag enabled, you may start connecting viewers to the stream via the Fishjam client SDKs or [WHEP](/how-to/features/whip-whep#public-livestreams).
+Once you've created a room of type `livestream` with the `public` flag enabled, you may start connecting viewers to the stream via the Fishjam client SDKs or [WHEP](../how-to/features/whip-whep#public-livestreams).
 
 <Tabs groupId="platform">
   <TabItem value="react" label="React">

--- a/versioned_docs/version-0.20.0/explanation/room-types.mdx
+++ b/versioned_docs/version-0.20.0/explanation/room-types.mdx
@@ -116,15 +116,15 @@ Livestream rooms are **20% cheaper** than conference rooms for equivalent usage.
 
 To understand how to use each room type:
 
-- [How to implement livestreaming](/tutorials/livestreaming)
-- [How to create audio-only calls](/how-to/features/audio-only-calls)
+- [How to implement livestreaming](../tutorials/livestreaming)
+- [How to create audio-only calls](../how-to/features/audio-only-calls)
 
 To learn about the underlying architecture:
 
-- [Fishjam Architecture](/explanation/architecture)
-- [Security & Token Model](/explanation/security-tokens)
+- [Fishjam Architecture](../explanation/architecture)
+- [Security & Token Model](../explanation/security-tokens)
 
 Ready to start building? Check our tutorials:
 
-- [React Native Quick Start](/tutorials/react-native-quick-start)
-- [Backend Quick Start](/tutorials/backend-quick-start)
+- [React Native Quick Start](../tutorials/react-native-quick-start)
+- [Backend Quick Start](../tutorials/backend-quick-start)

--- a/versioned_docs/version-0.20.0/explanation/sandbox-api-concept.mdx
+++ b/versioned_docs/version-0.20.0/explanation/sandbox-api-concept.mdx
@@ -69,13 +69,13 @@ This shows you exactly what your production backend needs to do, just with prope
 
 To understand how to use The Sandbox API for development:
 
-- [How to use The Sandbox API for testing](/how-to/features/sandbox-api-testing)
+- [How to use The Sandbox API for testing](../how-to/features/sandbox-api-testing)
 
 To learn about building your own backend:
 
-- [Backend Quick Start Tutorial](/tutorials/backend-quick-start)
-- [How to set up your server](/how-to/backend/server-setup)
+- [Backend Quick Start Tutorial](../tutorials/backend-quick-start)
+- [How to set up your server](../how-to/backend/server-setup)
 
 To understand the security model:
 
-- [Security & Token Model](/explanation/security-tokens)
+- [Security & Token Model](../explanation/security-tokens)

--- a/versioned_docs/version-0.20.0/explanation/security-tokens.mdx
+++ b/versioned_docs/version-0.20.0/explanation/security-tokens.mdx
@@ -36,8 +36,8 @@ Management tokens provide your backend server with administrative access to Fish
 Management tokens give permission to:
 
 - Create and manage rooms and peers
-- Setup [webhooks](/how-to/backend/server-setup#webhooks)
-- Set [immutable peer metadata](/how-to/backend/server-setup#metadata)
+- Setup [webhooks](../how-to/backend/server-setup#webhooks)
+- Set [immutable peer metadata](../how-to/backend/server-setup#metadata)
 
 ## Peer Tokens
 
@@ -110,13 +110,13 @@ await joinRoom({
 
 To implement secure authentication:
 
-- [Backend Quick Start Tutorial](/tutorials/backend-quick-start)
-- [How to set up your server](/how-to/backend/server-setup)
+- [Backend Quick Start Tutorial](../tutorials/backend-quick-start)
+- [How to set up your server](../how-to/backend/server-setup)
 
 To understand the broader architecture:
 
-- [Fishjam Architecture](/explanation/architecture)
+- [Fishjam Architecture](../explanation/architecture)
 
 To learn about the Sandbox API's security limitations:
 
-- [Understanding the Sandbox API](/explanation/sandbox-api-concept)
+- [Understanding the Sandbox API](../explanation/sandbox-api-concept)

--- a/versioned_docs/version-0.20.0/explanation/what-is-fishjam.mdx
+++ b/versioned_docs/version-0.20.0/explanation/what-is-fishjam.mdx
@@ -56,12 +56,12 @@ Create voice-only experiences like audio conferencing, podcasts, or voice chat a
 
 ## Next Steps
 
-To understand how Fishjam works technically, see [Fishjam Architecture](/explanation/architecture).
+To understand how Fishjam works technically, see [Fishjam Architecture](../explanation/architecture).
 
-To learn about the different types of rooms available, see [Room Types Explained](/explanation/room-types).
+To learn about the different types of rooms available, see [Room Types Explained](../explanation/room-types).
 
 Ready to start building? Check out our tutorials:
 
-- [React Native Quick Start](/tutorials/react-native-quick-start)
-- [React Quick Start](/tutorials/react-quick-start)
-- [Backend Quick Start](/tutorials/backend-quick-start)
+- [React Native Quick Start](../tutorials/react-native-quick-start)
+- [React Quick Start](../tutorials/react-quick-start)
+- [Backend Quick Start](../tutorials/backend-quick-start)

--- a/versioned_docs/version-0.20.0/how-to/_common/metadata/header.mdx
+++ b/versioned_docs/version-0.20.0/how-to/_common/metadata/header.mdx
@@ -4,7 +4,7 @@ However, it can be also used to send the peer's camera type, application informa
 
 :::info
 
-You can also set metadata on [the server side, when adding user to the room](/how-to/backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
+You can also set metadata on [the server side, when adding user to the room](../../../how-to/backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
 can't be overwritten by the peer, like information about real user names or basic permission info.
 
 :::

--- a/versioned_docs/version-0.20.0/how-to/_common/metadata/header.mdx
+++ b/versioned_docs/version-0.20.0/how-to/_common/metadata/header.mdx
@@ -4,7 +4,7 @@ However, it can be also used to send the peer's camera type, application informa
 
 :::info
 
-You can also set metadata on [the server side, when adding user to the room](../../../how-to/backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
+You can also set metadata on [the server side, when adding user to the room](../backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
 can't be overwritten by the peer, like information about real user names or basic permission info.
 
 :::

--- a/versioned_docs/version-0.20.0/how-to/_common/metadata/reading.mdx
+++ b/versioned_docs/version-0.20.0/how-to/_common/metadata/reading.mdx
@@ -4,6 +4,6 @@ Peer metadata is available as the `metadata` property for each peer. Therefore, 
 the metadata associated with them.
 Note that the `metadata.peer` property contains only the metadata set by the client SDK (as in the examples examples above).
 The metadata set on the server side is available as `metadata.server`.
-Learn more about server metadata [here](/how-to/backend/server-setup#metadata).
+Learn more about server metadata [here](../../backend/server-setup#metadata).
 
 {props.children}

--- a/versioned_docs/version-0.20.0/how-to/_common/metadata/reading.mdx
+++ b/versioned_docs/version-0.20.0/how-to/_common/metadata/reading.mdx
@@ -4,6 +4,6 @@ Peer metadata is available as the `metadata` property for each peer. Therefore, 
 the metadata associated with them.
 Note that the `metadata.peer` property contains only the metadata set by the client SDK (as in the examples examples above).
 The metadata set on the server side is available as `metadata.server`.
-Learn more about server metadata [here](../../backend/server-setup#metadata).
+Learn more about server metadata [here](../backend/server-setup#metadata).
 
 {props.children}

--- a/versioned_docs/version-0.20.0/how-to/backend/fastapi-example.mdx
+++ b/versioned_docs/version-0.20.0/how-to/backend/fastapi-example.mdx
@@ -6,7 +6,7 @@ title: FastAPI
 # FastAPI example
 
 The example assumes you've already installed [**our SDK**](https://github.com/fishjam-cloud/python-server-sdk) and you're ready to go.  
-If you wish to see more general info, visit [**Set up your server**](/how-to/backend/server-setup) article.
+If you wish to see more general info, visit [**Set up your server**](../../how-to/backend/server-setup) article.
 
 ## Minimal setup
 

--- a/versioned_docs/version-0.20.0/how-to/backend/fastify-example.mdx
+++ b/versioned_docs/version-0.20.0/how-to/backend/fastify-example.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 # Fastify example
 
 The example assumes you've already installed [**our SDK**](https://www.npmjs.com/package/@fishjam-cloud/js-server-sdk) and you're ready to go.  
-If you wish to see more general info, visit [**set up your server**](/how-to/backend/server-setup) article.
+If you wish to see more general info, visit [**set up your server**](../../how-to/backend/server-setup) article.
 
 ## Load environment variables to Fastify
 

--- a/versioned_docs/version-0.20.0/how-to/backend/production-deployment.mdx
+++ b/versioned_docs/version-0.20.0/how-to/backend/production-deployment.mdx
@@ -13,7 +13,7 @@ This guide covers the essential steps to move from development (using the Sandbo
 
 ## Prerequisites
 
-- Working Fishjam backend (see [Backend Quick Start](/tutorials/backend-quick-start))
+- Working Fishjam backend (see [Backend Quick Start](../../tutorials/backend-quick-start))
 - Production Fishjam environment (not Sandbox)
 - Domain and SSL certificates for your backend
 - Production database and infrastructure
@@ -291,10 +291,10 @@ However, if you wish to reuse a single peer over multiple days, you can make use
 
 For scaling considerations:
 
-- [Understanding Fishjam Architecture](/explanation/architecture)
-- [Security best practices](/explanation/security-tokens)
+- [Understanding Fishjam Architecture](../../explanation/architecture)
+- [Security best practices](../../explanation/security-tokens)
 
 For specific backend frameworks:
 
-- [FastAPI example](/how-to/backend/fastapi-example)
-- [Fastify example](/how-to/backend/fastify-example)
+- [FastAPI example](../../how-to/backend/fastapi-example)
+- [Fastify example](../../how-to/backend/fastify-example)

--- a/versioned_docs/version-0.20.0/how-to/backend/server-setup.mdx
+++ b/versioned_docs/version-0.20.0/how-to/backend/server-setup.mdx
@@ -164,8 +164,8 @@ At any time you can terminate user's access by deleting the peer.
 
 #### Metadata
 
-When creating a peer, you can also assign metadata to that peer, which can be read later with the [mobile SDK](/how-to/react-native/metadata-and-broadcasting)
-or [web SDK](/how-to/react/metadata). This metadata can be only set when creating the peer and can't be updated later.
+When creating a peer, you can also assign metadata to that peer, which can be read later with the [mobile SDK](../../how-to/react-native/metadata-and-broadcasting)
+or [web SDK](../../how-to/react/metadata). This metadata can be only set when creating the peer and can't be updated later.
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">

--- a/versioned_docs/version-0.20.0/how-to/features/audio-only-calls.mdx
+++ b/versioned_docs/version-0.20.0/how-to/features/audio-only-calls.mdx
@@ -22,7 +22,7 @@ If the same room were audio-only, then the final cost of the room will only be e
 
 ## How Do I Use It?
 
-Using this feature is as easy as setting the `roomType` field to `audio_only` when creating a room using our [Server SDKs](/how-to/backend/server-setup)
+Using this feature is as easy as setting the `roomType` field to `audio_only` when creating a room using our [Server SDKs](../../how-to/backend/server-setup)
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -49,7 +49,7 @@ Using this feature is as easy as setting the `roomType` field to `audio_only` wh
   </TabItem>
  </Tabs>
 
-Now, you can connect peers normally to the room as described in our [React Native](/how-to/react-native/connecting) and [React](/how-to/react/connecting) docs.
+Now, you can connect peers normally to the room as described in our [React Native](../../how-to/react-native/connecting) and [React](../../how-to/react/connecting) docs.
 
 :::info
 The React Native and React SDKs will log a warning in the console if any attempt to add video to an audio-only room is made.

--- a/versioned_docs/version-0.20.0/how-to/features/sandbox-api-testing.mdx
+++ b/versioned_docs/version-0.20.0/how-to/features/sandbox-api-testing.mdx
@@ -313,11 +313,11 @@ This will invalidate all existing tokens (including the management token!) and g
 
 Once you've tested your integration with the Sandbox API:
 
-- [Set up your own backend](/tutorials/backend-quick-start)
-- [Learn more about the Sandbox API](/explanation/sandbox-api-concept)
-- [Understand security implications](/explanation/security-tokens)
+- [Set up your own backend](../../tutorials/backend-quick-start)
+- [Learn more about the Sandbox API](../../explanation/sandbox-api-concept)
+- [Understand security implications](../../explanation/security-tokens)
 
 For production deployment:
 
-- [How to set up a production server](/how-to/backend/server-setup)
-- [How to implement proper authentication](/explanation/security-tokens)
+- [How to set up a production server](../../how-to/backend/server-setup)
+- [How to implement proper authentication](../../explanation/security-tokens)

--- a/versioned_docs/version-0.20.0/how-to/features/whip-whep.mdx
+++ b/versioned_docs/version-0.20.0/how-to/features/whip-whep.mdx
@@ -9,10 +9,10 @@ import TabItem from "@theme/TabItem";
 # Livestreaming using WHIP/WHEP
 
 :::tip
-Make sure to read [Livestreaming with Fishjam](/tutorials/livestreaming) before reading this guide.
+Make sure to read [Livestreaming with Fishjam](../../tutorials/livestreaming) before reading this guide.
 This guide focuses on a low-level way to communicate with Fishjam.
 
-The majority of use-cases should prefer to use the methods described in [Livestreaming with Fishjam](/tutorials/livestreaming).
+The majority of use-cases should prefer to use the methods described in [Livestreaming with Fishjam](../../tutorials/livestreaming).
 :::
 
 If you've reading this guide, it is more than likely that you've already heard of **WHIP** (WebRTC HTTP Ingress Protocol) and **WHEP** (WebRTC HTTP Egress Protocol).
@@ -44,7 +44,7 @@ You can paste this URL in your WHIP client of choice to start streaming.
 ### Getting the token
 
 To authenticate a streamer, you need to first create a room of type `livestream` and a streamer token for that room.
-You can read about this in detail in [Production Livestreaming with Server SDKs](/tutorials/livestreaming#production-livestreaming-with-server-sdks), but the TL;DR is
+You can read about this in detail in [Production Livestreaming with Server SDKs](../../tutorials/livestreaming#production-livestreaming-with-server-sdks), but the TL;DR is
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -102,7 +102,7 @@ The usage of WHEP is very similar to WHIP, as you need the following:
 With Fishjam, if the livestream is private, then the **token is required**.
 On the other hand, if the livestream is public, then the **token is omitted**.
 
-[Private vs Public Livestreams](/explanation/public-livestreams) explains private and public livestreams in more detail.
+[Private vs Public Livestreams](../../explanation/public-livestreams) explains private and public livestreams in more detail.
 In this guide we demonstrate how to view each livestream type using WHEP directly.
 
 ### Private livestreams
@@ -120,7 +120,7 @@ You can paste this URL in your WHEP client of choice to start viewing.
 #### Getting the token
 
 To authenticate a viewer, you need to create a viewer token for a room of `livestream` type.
-You can read about this in detail in [Production Livestreaming with Server SDKs](/tutorials/livestreaming#production-livestreaming-with-server-sdks), but the TL;DR is
+You can read about this in detail in [Production Livestreaming with Server SDKs](../../tutorials/livestreaming#production-livestreaming-with-server-sdks), but the TL;DR is
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -217,12 +217,12 @@ http://fishjam.io/api/v1/live/api/whep/[ROOM-ID]
 
 More on livestreaming:
 
-- [Livestreaming tutorial](/tutorials/livestreaming)
-- [Private vs Public livestreams](/explanation/public-livestreams)
+- [Livestreaming tutorial](../../tutorials/livestreaming)
+- [Private vs Public livestreams](../../explanation/public-livestreams)
 
 If livestreaming doesn't fit your use case:
 
-- [Room types explained](/explanation/room-types)
-- [Videoconferencing in React Native](/tutorials/react-native-quick-start)
-- [Videoconferencing in React](/tutorials/react-quick-start)
-- [Audio-only calls](/how-to/features/audio-only-calls)
+- [Room types explained](../../explanation/room-types)
+- [Videoconferencing in React Native](../../tutorials/react-native-quick-start)
+- [Videoconferencing in React](../../tutorials/react-quick-start)
+- [Audio-only calls](../../how-to/features/audio-only-calls)

--- a/versioned_docs/version-0.20.0/how-to/react-native/background-streaming.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react-native/background-streaming.mdx
@@ -61,12 +61,12 @@ You need to modify `AndroidManifest.xml` file and add below service:
 
   <TabItem value="android" label="Android">
 
-You can use [`useForegroundService`](/api/mobile/variables/useForegroundService) hook to handle how foreground service behaves on Android.
+You can use [`useForegroundService`](../../api/mobile/variables/useForegroundService) hook to handle how foreground service behaves on Android.
 
 :::important[Permissions]
 
-If you want to use [`enableCamera`](/api/mobile/type-aliases/ForegroundServiceConfig#enablecamera) or [`enableMicrophone`](/api/mobile/type-aliases/ForegroundServiceConfig#enablemicrophone),
-user must first grant permission for this resource. [`useForegroundService`](/api/mobile/variables/useForegroundService) will check if permission is
+If you want to use [`enableCamera`](../../api/mobile/type-aliases/ForegroundServiceConfig#enablecamera) or [`enableMicrophone`](../../api/mobile/type-aliases/ForegroundServiceConfig#enablemicrophone),
+user must first grant permission for this resource. [`useForegroundService`](../../api/mobile/variables/useForegroundService) will check if permission is
 granted and only then allow to start a service.
 
 :::

--- a/versioned_docs/version-0.20.0/how-to/react-native/connecting.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react-native/connecting.mdx
@@ -19,7 +19,7 @@ your Room).
   <TabItem value="sandbox" label="Sandbox App">
 
 Once you create your account on [Fishjam](https://fishjam.io), you will have access to the Sandbox environment as part of the Mini Jar plan.
-While using the Sandbox environment, [you can use the Sandbox API](/how-to/features/sandbox-api-testing) to generate peer tokens for testing or development purposes.
+While using the Sandbox environment, [you can use the Sandbox API](../../how-to/features/sandbox-api-testing) to generate peer tokens for testing or development purposes.
 This is basically a service that will create a Room, add your app as
 the Room's Peer, and return the token required to use that Room.
 
@@ -39,14 +39,14 @@ const peerToken = await getSandboxPeerToken(roomName, peerName);
   <TabItem value="production" label="Production App">
 
 For the production app, you need to implement your own backend service that will provide the user with a **Peer Token**. To do that,
-follow our [server setup instructions](/how-to/backend/server-setup).
+follow our [server setup instructions](../../how-to/backend/server-setup).
 
   </TabItem>
 </Tabs>
 
 ## Connecting
 
-In order to connect, call [`joinRoom`](/api/mobile/functions/useConnection#joinroom) method with the `peerToken` and the fishjam ID:
+In order to connect, call [`joinRoom`](../../api/mobile/functions/useConnection#joinroom) method with the `peerToken` and the fishjam ID:
 
 ```tsx
 import React, { useCallback } from "react";
@@ -73,7 +73,7 @@ export function JoinRoomButton() {
 
 ## Disconnecting
 
-In order to close the connection, you have to call [`leaveRoom`](/api/mobile/functions/useConnection#leaveroom) method.
+In order to close the connection, you have to call [`leaveRoom`](../../api/mobile/functions/useConnection#leaveroom) method.
 
 ```tsx
 import React, { useCallback } from "react";

--- a/versioned_docs/version-0.20.0/how-to/react-native/custom-video-sources/index.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react-native/custom-video-sources/index.mdx
@@ -10,5 +10,5 @@ This section contains guides for implementing custom video sources in the Fishja
 
 ## Available Guides
 
-- [Custom Source](/how-to/react-native/custom-video-sources/overview) - Learn how to create a basic custom video source
-- [Vision Camera](/how-to/react-native/custom-video-sources/vision-camera) - Learn how to implement Vision Camera as a custom video source
+- [Custom Source](../../../how-to/react-native/custom-video-sources/overview) - Learn how to create a basic custom video source
+- [Vision Camera](../../../how-to/react-native/custom-video-sources/vision-camera) - Learn how to implement Vision Camera as a custom video source

--- a/versioned_docs/version-0.20.0/how-to/react-native/list-other-peers.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react-native/list-other-peers.mdx
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # List other peers
 
-In order to see other streaming peers, you can use [`usePeers`](/api/mobile/functions/usePeers). It will return all  
+In order to see other streaming peers, you can use [`usePeers`](../../api/mobile/functions/usePeers). It will return all  
 other peers, together with the tracks that they are streaming.
 
 ### Example code that show all videos

--- a/versioned_docs/version-0.20.0/how-to/react-native/reconnection-handling.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react-native/reconnection-handling.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 # Reconnect
 
 If your connection is lost while you are connected to a room, the app will automatically handle the reconnection process.
-You can monitor these events by utilizing the [`useConnection`](/api/mobile/functions/useConnection) hook.
+You can monitor these events by utilizing the [`useConnection`](../../api/mobile/functions/useConnection) hook.
 
 ### Example hook that logs the current status to the console
 

--- a/versioned_docs/version-0.20.0/how-to/react-native/screensharing.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react-native/screensharing.mdx
@@ -152,11 +152,11 @@ Configuring screen sharing on iOS is a little complicated.
 
 ## Usage
 
-You can use [`useScreenShare`](/api/mobile/functions/useScreenShare) hook to enable screen sharing.
+You can use [`useScreenShare`](../../api/mobile/functions/useScreenShare) hook to enable screen sharing.
 
 :::tip[Permissions]
 
-Permission request is handled for you as soon as you call [`toggleScreenShare`](/api/mobile/functions/useScreenShare#togglescreenshare).
+Permission request is handled for you as soon as you call [`toggleScreenShare`](../../api/mobile/functions/useScreenShare#togglescreenshare).
 
 :::
 
@@ -166,8 +166,8 @@ On Android API level >= 24, you must use a foreground service when screen sharin
 
 :::
 
-You can enable/disable screen sharing with [`toggleScreenShare`](/api/mobile/functions/useScreenShare#togglescreenshare) method.
-And check current state with [`isScreenShareOn`](/api/mobile/functions/useScreenShare#isscreenshareon) property.
+You can enable/disable screen sharing with [`toggleScreenShare`](../../api/mobile/functions/useScreenShare#togglescreenshare) method.
+And check current state with [`isScreenShareOn`](../../api/mobile/functions/useScreenShare#isscreenshareon) property.
 
 ```tsx
 import React, { useCallback } from "react";

--- a/versioned_docs/version-0.20.0/how-to/react-native/start-streaming.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react-native/start-streaming.mdx
@@ -16,8 +16,8 @@ enabled camera and microphone will start streaming to Room.
 
 ## Enable your camera
 
-First, you have to enable your camera by calling [`prepareCamera`](/api/mobile/functions/useCamera#preparecamera) method.
-You can open show camera preview with [`VideoPreviewView`](/api/mobile/variables/VideoPreviewView) component
+First, you have to enable your camera by calling [`prepareCamera`](../../api/mobile/functions/useCamera#preparecamera) method.
+You can open show camera preview with [`VideoPreviewView`](../../api/mobile/variables/VideoPreviewView) component
 
 ```tsx
 import React, { useEffect } from "react";
@@ -39,10 +39,10 @@ export function ViewPreview() {
 
 ### Listing user cameras
 
-To list all cameras available on device, you can use [`cameras`](/api/mobile/functions/useCamera#cameras) property from [`useCamera`](/api/mobile/functions/useCamera) hook.
+To list all cameras available on device, you can use [`cameras`](../../api/mobile/functions/useCamera#cameras) property from [`useCamera`](../../api/mobile/functions/useCamera) hook.
 This way, you can either automatically choose camera (front/back) or allow user to select camera type.
 
-To change camera, simply call [`switchCamera`](/api/mobile/functions/useCamera#switchcamera) method.
+To change camera, simply call [`switchCamera`](../../api/mobile/functions/useCamera#switchcamera) method.
 
 ```tsx
 import React, { useCallback } from "react";
@@ -68,7 +68,7 @@ export function FlipButton() {
 
 ### Disabling/enabling camera
 
-To change camera state, you use [`toggleCamera`](/api/mobile/functions/useCamera#togglecamera) method.
+To change camera state, you use [`toggleCamera`](../../api/mobile/functions/useCamera#togglecamera) method.
 
 ```tsx
 import { Button } from "react-native";
@@ -89,7 +89,7 @@ export function ToggleCameraButton() {
 
 ## Enable microphone
 
-Microphone works similar to camera. In order to enable it, you have to call [`toggleMicrophone`](/api/mobile/functions/useMicrophone#togglemicrophone) method.
+Microphone works similar to camera. In order to enable it, you have to call [`toggleMicrophone`](../../api/mobile/functions/useMicrophone#togglemicrophone) method.
 
 ```tsx
 import { Button } from "react-native";

--- a/versioned_docs/version-0.20.0/how-to/react/_common/metadata/header.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/_common/metadata/header.mdx
@@ -4,7 +4,7 @@ However, it can be also used to send the peer's camera type, application informa
 
 :::info
 
-You can also set metadata on [the server side, when adding user to the room](/how-to/backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
+You can also set metadata on [the server side, when adding user to the room](../backend/server-setup#metadata). This metadata is persistent throughout its lifetime and is useful for attaching information that
 can't be overwritten by the peer, like information about real user names or basic permission info.
 
 :::

--- a/versioned_docs/version-0.20.0/how-to/react/_common/metadata/reading.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/_common/metadata/reading.mdx
@@ -4,6 +4,6 @@ Peer metadata is available as the `metadata` property for each peer. Therefore, 
 the metadata associated with them.
 Note that the `metadata.peer` property contains only the metadata set by the client SDK (as in the examples examples above).
 The metadata set on the server side is available as `metadata.server`.
-Learn more about server metadata [here](/how-to/backend/server-setup#metadata).
+Learn more about server metadata [here](../backend/server-setup#metadata).
 
 {props.children}

--- a/versioned_docs/version-0.20.0/how-to/react/connecting.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/connecting.mdx
@@ -7,12 +7,12 @@ sidebar_position: 2
 ## Prerequisites
 
 In order to connect, you need to obtain a **Peer Token** to authorize the peer in your room.
-You can get the token using the [Sandbox API](/how-to/features/sandbox-api-testing) if you're using the Sandbox environment, or implement your own backend service that will provide the user with a **Peer Token**.
+You can get the token using the [Sandbox API](../../how-to/features/sandbox-api-testing) if you're using the Sandbox environment, or implement your own backend service that will provide the user with a **Peer Token**.
 
 ## Connecting
 
-Use the [`useConnection`](/api/web/functions/useConnection) hook to get
-the [`joinRoom`](/api/web/functions/useConnection#joinroom) function.
+Use the [`useConnection`](../../api/web/functions/useConnection) hook to get
+the [`joinRoom`](../../api/web/functions/useConnection#joinroom) function.
 
 ```tsx
 const PEER_TOKEN = "some-peer-token";
@@ -37,8 +37,8 @@ export function JoinRoomButton() {
 
 ## Disconnecting
 
-In order to close connection, use the [`leaveRoom`](/api/web/functions/useConnection#leaveroom) method
-from [`useConnection`](/api/web/functions/useConnection) hook.
+In order to close connection, use the [`leaveRoom`](../../api/web/functions/useConnection#leaveroom) method
+from [`useConnection`](../../api/web/functions/useConnection) hook.
 
 ```tsx
 import { useConnection } from "@fishjam-cloud/react-client";

--- a/versioned_docs/version-0.20.0/how-to/react/custom-sources.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/custom-sources.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 :::important
 
-If you only wish to send camera, microphone or screen share output through Fishjam, then you most likely should refer to the documentation in [Streaming media](/how-to/react/start-streaming) and [Managing devices](/how-to/react/managing-devices) instead of this page.
+If you only wish to send camera, microphone or screen share output through Fishjam, then you most likely should refer to the documentation in [Streaming media](../../how-to/react/start-streaming) and [Managing devices](../../how-to/react/managing-devices) instead of this page.
 
 :::
 
@@ -17,12 +17,12 @@ This section demonstrates how to stream non-standard video or audio to other pee
 The utilities in this section allow you to integrate Fishjam with powerful browser APIs such as [WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API) and [WebGPU](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API),
 or higher level libraries, which leverage these APIs, such as [Three.js](https://threejs.org/), [Smelter](https://smelter.dev) or [PixiJS](https://pixijs.com/)
 
-## Creating a custom source - [`useCustomSource()`](/api/web/functions/useCustomSource)
+## Creating a custom source - [`useCustomSource()`](../../api/web/functions/useCustomSource)
 
 To create a custom source, you only need to do two things:
 
 1. Call the `useCustomSource` hook.
-2. Call the [`setStream`](/api/web/functions/useCustomSource#setstream) callback provided by the `useCustomSource` hook with a [MediaStream](#how-to-get-a-mediastream-object) object.
+2. Call the [`setStream`](../../api/web/functions/useCustomSource#setstream) callback provided by the `useCustomSource` hook with a [MediaStream](#how-to-get-a-mediastream-object) object.
 
 #### Usage Example
 
@@ -40,12 +40,12 @@ useEffect(() => {
 
 ### Using a created custom source
 
-Once you have called [`setStream`](/api/web/functions/useCustomSource#setstream) for a given source ID (in the above example, `"my-custom-source"`), any subsequent calls to `useCustomSource` with the same ID will return the same state.
+Once you have called [`setStream`](../../api/web/functions/useCustomSource#setstream) for a given source ID (in the above example, `"my-custom-source"`), any subsequent calls to `useCustomSource` with the same ID will return the same state.
 This enables multiple components to control and read a shared custom source.
 
 ### Deleting a custom source
 
-If you wish to remove a custom source, then you should call the [`setStream`](/api/web/functions/useCustomSource#setstream) callback with `null` as its argument.
+If you wish to remove a custom source, then you should call the [`setStream`](../../api/web/functions/useCustomSource#setstream) callback with `null` as its argument.
 
 #### Usage Example
 

--- a/versioned_docs/version-0.20.0/how-to/react/installation.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/installation.mdx
@@ -15,7 +15,7 @@ npm install @fishjam-cloud/react-client
 
 ## 2. Setup Fishjam context
 
-Wrap your app in our [`FishjamProvider`](/api/web/functions/FishjamProvider) component. Get your Fishjam ID from [Fishjam Dashboard](https://fishjam.io/app) and pass it to the provider.
+Wrap your app in our [`FishjamProvider`](../../api/web/functions/FishjamProvider) component. Get your Fishjam ID from [Fishjam Dashboard](https://fishjam.io/app) and pass it to the provider.
 
 ```tsx
 const App = () => {
@@ -44,6 +44,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 :::tip
 
 It's possible to have many independent Fishjam contexts in one app.  
-Just render many [`FishjamProvider`](/api/web/functions/FishjamProvider) components and make sure they don't overlap.
+Just render many [`FishjamProvider`](../../api/web/functions/FishjamProvider) components and make sure they don't overlap.
 
 :::

--- a/versioned_docs/version-0.20.0/how-to/react/list-other-peers.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/list-other-peers.mdx
@@ -4,8 +4,8 @@ sidebar_position: 5
 
 # Display media of other peers
 
-To access data and media of other peers, use the [`usePeers`](/api/web/functions/usePeers) hook.
-It returns two properties, [`remotePeers`](/api/web/functions/usePeers) and [`localPeer`](/api/web/functions/usePeers).
+To access data and media of other peers, use the [`usePeers`](../../api/web/functions/usePeers) hook.
+It returns two properties, [`remotePeers`](../../api/web/functions/usePeers) and [`localPeer`](../../api/web/functions/usePeers).
 They contain all the tracks of other peers and all the tracks of the local user, respectively.
 
 ### Example of playing other peers' available media

--- a/versioned_docs/version-0.20.0/how-to/react/managing-devices.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/managing-devices.mdx
@@ -6,10 +6,10 @@ sidebar_position: 4
 
 The Fishjam SDK provides functions for dynamically controlling media device streams. This includes selecting desired cameras and microphones, turning them on and off, as well as muting and unmuting microphones.
 
-### Selecting Camera and Microphone - [`selectCamera()`](/api/web/functions/useCamera#selectcamera) and [`selectMicrophone()`](/api/web/functions/useMicrophone#selectmicrophone)
+### Selecting Camera and Microphone - [`selectCamera()`](../../api/web/functions/useCamera#selectcamera) and [`selectMicrophone()`](../../api/web/functions/useMicrophone#selectmicrophone)
 
-To select the desired camera or microphone, use the [`selectCamera()`](/api/web/functions/useCamera#selectcamera) and [`selectMicrophone()`](/api/web/functions/useMicrophone#selectmicrophone) functions.  
-Lists of the available devices are available via the [`cameraDevices`](/api/web/functions/useCamera#cameradevices) and [`microphoneDevices`](/api/web/functions/useMicrophone#microphonedevices) properties.
+To select the desired camera or microphone, use the [`selectCamera()`](../../api/web/functions/useCamera#selectcamera) and [`selectMicrophone()`](../../api/web/functions/useMicrophone#selectmicrophone) functions.  
+Lists of the available devices are available via the [`cameraDevices`](../../api/web/functions/useCamera#cameradevices) and [`microphoneDevices`](../../api/web/functions/useMicrophone#microphonedevices) properties.
 
 #### Usage Example
 
@@ -32,7 +32,7 @@ export function CameraControl() {
 }
 ```
 
-### Turning Camera On and Off - [`toggleCamera()`](/api/web/functions/useCamera#togglecamera)
+### Turning Camera On and Off - [`toggleCamera()`](../../api/web/functions/useCamera#togglecamera)
 
 This function controls the physical operational state of the camera.
 
@@ -52,14 +52,14 @@ export function CameraControl() {
 }
 ```
 
-### Turning Microphone On and Off - [`toggleMicrophone()`](/api/web/functions/useMicrophone#togglemicrophone)
+### Turning Microphone On and Off - [`toggleMicrophone()`](../../api/web/functions/useMicrophone#togglemicrophone)
 
 This function toggles the microphone's physical operational state. The function interacts with a physical device, so it might take a noticeable amount of time.
 
 - **Turning the microphone off**: Turns the microphone off, disables the media stream, and pauses any audio transmission.
 - **Turning the microphone on**: Turns the microphone on and resumes audio streaming.
 
-### Muting and Unmuting Microphone - [`toggleMicrophoneMute()`](/api/web/functions/useMicrophone#togglemicrophonemute)
+### Muting and Unmuting Microphone - [`toggleMicrophoneMute()`](../../api/web/functions/useMicrophone#togglemicrophonemute)
 
 This function manages the audio stream's operational status without affecting the microphone's hardware state.
 Muting and unmuting is faster, but a muted device still uses resources. This is useful, as it is common to mute and unmute during a meeting. Unmuting needs to be quick to capture the first word of a sentence.

--- a/versioned_docs/version-0.20.0/how-to/react/start-streaming.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/start-streaming.mdx
@@ -8,13 +8,13 @@ sidebar_position: 3
 
 Fishjam provides an API to browse and manage media devices you can use.  
 To ask the browser for permission to list the available devices,
-call the [`initializeDevices`](/api/web/functions/useInitializeDevices#initializedevices)
-function from [`useInitializeDevices`](/api/web/functions/useInitializeDevices) hook.
+call the [`initializeDevices`](../../api/web/functions/useInitializeDevices#initializedevices)
+function from [`useInitializeDevices`](../../api/web/functions/useInitializeDevices) hook.
 
-You can choose whether to initialize both camera and microphone devices or just one of them by passing [`InitializeDevicesSettings`](/api/web/type-aliases/InitializeDevicesSettings)
+You can choose whether to initialize both camera and microphone devices or just one of them by passing [`InitializeDevicesSettings`](../../api/web/type-aliases/InitializeDevicesSettings)
 as an argument. By default, both camera and microphone are initialized.
 
-The [`initializeDevices`](/api/web/functions/useInitializeDevices#initializedevices) function will return a [`Promise<InitializeDevicesResult>`](/api/web/type-aliases/InitializeDevicesResult) object.
+The [`initializeDevices`](../../api/web/functions/useInitializeDevices#initializedevices) function will return a [`Promise<InitializeDevicesResult>`](../../api/web/type-aliases/InitializeDevicesResult) object.
 
 ```ts
 import React, { useEffect } from "react";
@@ -33,15 +33,15 @@ export function useExample() {
 ```
 
 :::note
-The [`useInitializeDevices`](/api/web/functions/useInitializeDevices) hook gives you the convenience of asking the user for all permissions at once.
+The [`useInitializeDevices`](../../api/web/functions/useInitializeDevices) hook gives you the convenience of asking the user for all permissions at once.
 
-It is not the only way to enable the device. You can just toggle the device using [`useCamera`](/api/web/functions/useCamera) or [`useMicrophone`](/api/web/functions/useMicrophone) hooks.
+It is not the only way to enable the device. You can just toggle the device using [`useCamera`](../../api/web/functions/useCamera) or [`useMicrophone`](../../api/web/functions/useMicrophone) hooks.
 :::
 
 ### Device API
 
-To manage users' camera and microphone devices, use the respective [`useCamera`](/api/web/functions/useCamera)
-and [`useMicrophone`](/api/web/functions/useMicrophone) hooks.
+To manage users' camera and microphone devices, use the respective [`useCamera`](../../api/web/functions/useCamera)
+and [`useMicrophone`](../../api/web/functions/useMicrophone) hooks.
 Both of them has similar API. To keep things simple, we will just use the camera hook.
 
 ```tsx

--- a/versioned_docs/version-0.20.0/how-to/react/stream-middleware.mdx
+++ b/versioned_docs/version-0.20.0/how-to/react/stream-middleware.mdx
@@ -9,7 +9,7 @@ This feature is powerful for applying effects, custom encodings, or any other tr
 
 ## Overview
 
-Define a [`TrackMiddleware`](/api/web/type-aliases/TrackMiddleware) function which takes a `MediaStreamTrack` and returns an object containing the modified `MediaStreamTrack`
+Define a [`TrackMiddleware`](../../api/web/type-aliases/TrackMiddleware) function which takes a `MediaStreamTrack` and returns an object containing the modified `MediaStreamTrack`
 and an optional `onClear` function, which is called when the middleware needs to be removed or reapplied when a device changes.
 
 ### Type definition
@@ -22,11 +22,11 @@ export type TrackMiddleware = (
 
 ### Setting middleware
 
-You can set the middleware for your media tracks using [`setTrackMiddleware`](/api/web/functions/useCamera) method. This method accepts a `TrackMiddleware` or `null` for removing previously set middleware.
+You can set the middleware for your media tracks using [`setTrackMiddleware`](../../api/web/functions/useCamera) method. This method accepts a `TrackMiddleware` or `null` for removing previously set middleware.
 
 ### Example: Applying a blur effect
 
-The following example demonstrates how to apply a custom blur effect to the camera track using the [`useCamera`](/api/web/functions/useCamera) hook and middleware.
+The following example demonstrates how to apply a custom blur effect to the camera track using the [`useCamera`](../../api/web/functions/useCamera) hook and middleware.
 
 ```tsx
 class BlurProcessor {

--- a/versioned_docs/version-0.20.0/how-to/troubleshooting/video-codecs.mdx
+++ b/versioned_docs/version-0.20.0/how-to/troubleshooting/video-codecs.mdx
@@ -19,7 +19,7 @@ Fishjam uses H.264 by default, however, to solve an issue with Android emulators
 
 ### Changing the Codec
 
-Override the default codec by setting the `codec` parameter when [creating a room](/api/server/interfaces/RoomConfig#videocodec) using server SDKs.
+Override the default codec by setting the `codec` parameter when [creating a room](../../api/server/interfaces/RoomConfig#videocodec) using server SDKs.
 
 ### Why VP8 and H.264?
 

--- a/versioned_docs/version-0.20.0/index.mdx
+++ b/versioned_docs/version-0.20.0/index.mdx
@@ -35,10 +35,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="/tutorials/react-native-quick-start">React Native Quick Start</a></li>
-      <li><a href="/tutorials/react-quick-start">React Quick Start</a></li>
-      <li><a href="/tutorials/backend-quick-start">Backend Quick Start</a></li>
-      <li><a href="/tutorials" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href="./tutorials/react-native-quick-start">React Native Quick Start</a></li>
+      <li><a href="./tutorials/react-quick-start">React Quick Start</a></li>
+      <li><a href="./tutorials/backend-quick-start">Backend Quick Start</a></li>
+      <li><a href="./tutorials" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -62,10 +62,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="/how-to/react-native/installation">React Native Installation and Setup</a></li>
-      <li><a href="/how-to/react/installation">React Installation and Setup</a></li>
-      <li><a href="/how-to/backend/production-deployment">Backend Production Deployment</a></li>
-      <li><a href="/how-to" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href="./how-to/react-native/installation">React Native Installation and Setup</a></li>
+      <li><a href="./how-to/react/installation">React Installation and Setup</a></li>
+      <li><a href="./how-to/backend/production-deployment">Backend Production Deployment</a></li>
+      <li><a href="./how-to" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -89,10 +89,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="/explanation/what-is-fishjam">What is Fishjam?</a></li>
-      <li><a href="/explanation/architecture">Architecture Overview</a></li>
-      <li><a href="/explanation/sandbox-api-concept">Sandbox API</a></li>
-      <li><a href="/explanation" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href="./explanation/what-is-fishjam">What is Fishjam?</a></li>
+      <li><a href="./explanation/architecture">Architecture Overview</a></li>
+      <li><a href="./explanation/sandbox-api-concept">Sandbox API</a></li>
+      <li><a href="./explanation" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -116,10 +116,10 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="/api/mobile">React Native SDK API</a></li>
-      <li><a href="/api/web">React/Web SDK API</a></li>
-      <li><a href="/api/server">Server SDK API</a></li>
-      <li><a href="/api" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href="./api/mobile">React Native SDK API</a></li>
+      <li><a href="./api/web">React/Web SDK API</a></li>
+      <li><a href="./api/server">Server SDK API</a></li>
+      <li><a href="./api" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>

--- a/versioned_docs/version-0.20.0/index.mdx
+++ b/versioned_docs/version-0.20.0/index.mdx
@@ -4,6 +4,7 @@ sidebar_position: 0
 
 import QuickNavigation from "@site/src/components/QuickNavigation";
 import { items } from "@site/src/content/cardItems";
+import { useVersionedLink } from "@site/src/hooks/useVersionedLink";
 
 # Welcome to Fishjam
 
@@ -38,7 +39,7 @@ To get started, we recommend you check out one of the two guides below:
       <li><a href="./tutorials/react-native-quick-start">React Native Quick Start</a></li>
       <li><a href="./tutorials/react-quick-start">React Quick Start</a></li>
       <li><a href="./tutorials/backend-quick-start">Backend Quick Start</a></li>
-      <li><a href="./tutorials" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href={useVersionedLink("tutorials")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -65,7 +66,7 @@ To get started, we recommend you check out one of the two guides below:
       <li><a href="./how-to/react-native/installation">React Native Installation and Setup</a></li>
       <li><a href="./how-to/react/installation">React Installation and Setup</a></li>
       <li><a href="./how-to/backend/production-deployment">Backend Production Deployment</a></li>
-      <li><a href="./how-to" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href={useVersionedLink("how-to")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -92,7 +93,7 @@ To get started, we recommend you check out one of the two guides below:
       <li><a href="./explanation/what-is-fishjam">What is Fishjam?</a></li>
       <li><a href="./explanation/architecture">Architecture Overview</a></li>
       <li><a href="./explanation/sandbox-api-concept">Sandbox API</a></li>
-      <li><a href="./explanation" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href={useVersionedLink("explanation")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>
@@ -119,7 +120,7 @@ To get started, we recommend you check out one of the two guides below:
       <li><a href="./api/mobile">React Native SDK API</a></li>
       <li><a href="./api/web">React/Web SDK API</a></li>
       <li><a href="./api/server">Server SDK API</a></li>
-      <li><a href="./api" style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
+      <li><a href={useVersionedLink("api")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
   </div>

--- a/versioned_docs/version-0.20.0/index.mdx
+++ b/versioned_docs/version-0.20.0/index.mdx
@@ -36,9 +36,9 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="./tutorials/react-native-quick-start">React Native Quick Start</a></li>
-      <li><a href="./tutorials/react-quick-start">React Quick Start</a></li>
-      <li><a href="./tutorials/backend-quick-start">Backend Quick Start</a></li>
+      <li>[React Native Quick Start](./tutorials/react-native-quick-start.mdx)</li>
+      <li>[React Quick Start](./tutorials/react-quick-start.mdx)</li>
+      <li>[Backend Quick Start](./tutorials/backend-quick-start.mdx)</li>
       <li><a href={useVersionedLink("tutorials")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
@@ -63,9 +63,9 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="./how-to/react-native/installation">React Native Installation and Setup</a></li>
-      <li><a href="./how-to/react/installation">React Installation and Setup</a></li>
-      <li><a href="./how-to/backend/production-deployment">Backend Production Deployment</a></li>
+      <li>[React Native Installation and Setup](./how-to/react-native/installation.mdx)</li>
+      <li>[React Installation and Setup](./how-to/react/installation.mdx)</li>
+      <li>[Backend Production Deployment](./how-to/backend/production-deployment.mdx)</li>
       <li><a href={useVersionedLink("how-to")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
@@ -90,9 +90,9 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="./explanation/what-is-fishjam">What is Fishjam?</a></li>
-      <li><a href="./explanation/architecture">Architecture Overview</a></li>
-      <li><a href="./explanation/sandbox-api-concept">Sandbox API</a></li>
+      <li>[What is Fishjam?](./explanation/what-is-fishjam.mdx)</li>
+      <li>[Architecture Overview](./explanation/architecture.mdx)</li>
+      <li>[Sandbox API](./explanation/sandbox-api-concept.mdx)</li>
       <li><a href={useVersionedLink("explanation")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 
@@ -117,9 +117,9 @@ To get started, we recommend you check out one of the two guides below:
   </div>
     <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
       <ul style={{ listStyle: "none", textAlign: "right" }}>
-      <li><a href="./api/mobile">React Native SDK API</a></li>
-      <li><a href="./api/web">React/Web SDK API</a></li>
-      <li><a href="./api/server">Server SDK API</a></li>
+      <li>[React Native SDK API](./api/mobile/index.md)</li>
+      <li>[React SDK API](./api/web/index.md)</li>
+      <li>[Server SDK API](./api/server/index.md)</li>
       <li><a href={useVersionedLink("api")} style={{ fontSize: "1.1rem", fontWeight: "bold" }}>See all →</a></li>
     </ul>
 

--- a/versioned_docs/version-0.20.0/tutorials/backend-quick-start.mdx
+++ b/versioned_docs/version-0.20.0/tutorials/backend-quick-start.mdx
@@ -550,12 +550,12 @@ Here's a complete working backend:
 
 Now that you have a working backend, explore these guides:
 
-- [How to set up a production deployment](/how-to/backend/production-deployment)
-- [How to handle webhooks and events](/how-to/backend/server-setup)
-- [How to implement a FastAPI backend](/how-to/backend/fastapi-example)
-- [How to implement a Fastify backend](/how-to/backend/fastify-example)
+- [How to set up a production deployment](../how-to/backend/production-deployment)
+- [How to handle webhooks and events](../how-to/backend/server-setup)
+- [How to implement a FastAPI backend](../how-to/backend/fastapi-example)
+- [How to implement a Fastify backend](../how-to/backend/fastify-example)
 
 Or learn more about Fishjam concepts:
 
-- [Understanding security and tokens](/explanation/security-tokens)
-- [Room types explained](/explanation/room-types)
+- [Understanding security and tokens](../explanation/security-tokens)
+- [Room types explained](../explanation/room-types)

--- a/versioned_docs/version-0.20.0/tutorials/livestreaming.mdx
+++ b/versioned_docs/version-0.20.0/tutorials/livestreaming.mdx
@@ -16,7 +16,7 @@ and how to get ready for production in [Production Livestreaming with Server SDK
 Fishjam implements two real-time streaming standards: WHIP (for publishing) and WHEP (for receiving).
 
 In this tutorial we explain how to publish and view streams with the client SDKs, which wrap these standards.
-If you prefer to use WHIP or WHEP directly, then you should read [WHIP/WHEP with Fishjam](/how-to/features/whip-whep).
+If you prefer to use WHIP or WHEP directly, then you should read [WHIP/WHEP with Fishjam](../how-to/features/whip-whep).
 :::
 
 ## Quickstart with Sandbox API
@@ -180,7 +180,7 @@ To receive the published livestream, we need one thing: a _viewer token_.
 In this guide, we've created a _private_ livestream, where viewers need a token to join.
 A livestream may also be _public_, where anyone can join if they know the livestream's room id.
 
-You can learn more about public livestreams in [Private vs Public Livestreams](/explanation/public-livestreams).
+You can learn more about public livestreams in [Private vs Public Livestreams](../explanation/public-livestreams).
 :::
 
 #### Obtaining a token
@@ -332,15 +332,15 @@ Then, you can start streaming as described in [Starting the stream](#starting-th
 
 Learn how to use WHIP/WHEP with Fishjam:
 
-- [WHIP/WHEP with Fishjam](/how-to/features/whip-whep)
+- [WHIP/WHEP with Fishjam](../how-to/features/whip-whep)
 
 If you want to get a better understanding of livestreaming with Fishjam, make sure to check out:
 
-- [Room Types Explained](/explanation/room-types)
-- [Private vs Public Livestreams](/explanation/public-livestreams)
+- [Room Types Explained](../explanation/room-types)
+- [Private vs Public Livestreams](../explanation/public-livestreams)
 
 If you have a different use case, then you should see
 
-- [React Quickstart](/tutorials/react-quick-start)
-- [React Native Quickstart](/tutorials/react-native-quick-start)
-- [Audio-only Calls](/how-to/features/audio-only-calls)
+- [React Quickstart](../tutorials/react-quick-start)
+- [React Native Quickstart](../tutorials/react-native-quick-start)
+- [Audio-only Calls](../how-to/features/audio-only-calls)

--- a/versioned_docs/version-0.20.0/tutorials/react-native-quick-start.mdx
+++ b/versioned_docs/version-0.20.0/tutorials/react-native-quick-start.mdx
@@ -196,12 +196,12 @@ export default function HomeScreen() {
 
 Now that you have a basic app working, explore these how-to guides:
 
-- [How to handle screen sharing](/how-to/react-native/screensharing)
-- [How to implement background streaming](/how-to/react-native/background-streaming)
-- [How to handle reconnections](/how-to/react-native/reconnection-handling)
-- [How to work with metadata](/how-to/react-native/metadata-and-broadcasting)
+- [How to handle screen sharing](../how-to/react-native/screensharing)
+- [How to implement background streaming](../how-to/react-native/background-streaming)
+- [How to handle reconnections](../how-to/react-native/reconnection-handling)
+- [How to work with metadata](../how-to/react-native/metadata-and-broadcasting)
 
 Or learn more about Fishjam concepts:
 
-- [Understanding Fishjam architecture](/explanation/architecture)
-- [Room types explained](/explanation/room-types)
+- [Understanding Fishjam architecture](../explanation/architecture)
+- [Room types explained](../explanation/room-types)

--- a/versioned_docs/version-0.20.0/tutorials/react-quick-start.mdx
+++ b/versioned_docs/version-0.20.0/tutorials/react-quick-start.mdx
@@ -274,12 +274,12 @@ export default function App() {
 
 Now that you have a basic app working, explore these how-to guides:
 
-- [How to manage media devices](/how-to/react/managing-devices)
-- [How to implement livestreaming](/tutorials/livestreaming)
-- [How to work with stream middleware](/how-to/react/stream-middleware)
-- [How to handle custom sources](/how-to/react/custom-sources)
+- [How to manage media devices](../how-to/react/managing-devices)
+- [How to implement livestreaming](../tutorials/livestreaming)
+- [How to work with stream middleware](../how-to/react/stream-middleware)
+- [How to handle custom sources](../how-to/react/custom-sources)
 
 Or learn more about Fishjam concepts:
 
-- [Understanding Fishjam architecture](/explanation/architecture)
-- [Room types explained](/explanation/room-types)
+- [Understanding Fishjam architecture](../explanation/architecture)
+- [Room types explained](../explanation/room-types)


### PR DESCRIPTION
## Description

part of FCE-1889

versioned docs don't work with twoslash: https://linear.app/swmansion/issue/FCE-1897/make-twoslash-work-with-versioned-docs

also, the sidebar generation for the api reference didn't work with versioned docs, but that was easy to fix
