### PR TITLE
Fix broken anchors

### DIFF
--- a/docs/explanation/agent-internals.mdx
+++ b/docs/explanation/agent-internals.mdx
@@ -71,7 +71,7 @@ Once connected, an agent will receive chunks of audio as [`AgentRequest.TrackDat
 
 ### Step 4. Disconnecting from the Room
 
-An agent disconnects from the room by closing the WebSocket connection created in [Step 2](#step-2-connecting-to-the-room).
+An agent disconnects from the room by closing the WebSocket connection created in [Step 2](#step-2.-connecting-to-the-room).
 It may reconnect using the same token it provided in [Step 2](#step-2-connecting-to-the-room).
 
 ## Peer subscriptions

--- a/docs/explanation/agent-internals.mdx
+++ b/docs/explanation/agent-internals.mdx
@@ -71,7 +71,7 @@ Once connected, an agent will receive chunks of audio as [`AgentRequest.TrackDat
 
 ### Step 4. Disconnecting from the Room
 
-An agent disconnects from the room by closing the WebSocket connection created in [Step 2](#step-2.-connecting-to-the-room).
+An agent disconnects from the room by closing the WebSocket connection created in [Step 2](#step-2-connecting-to-the-room).
 It may reconnect using the same token it provided in [Step 2](#step-2-connecting-to-the-room).
 
 ## Peer subscriptions

--- a/docs/explanation/agent-internals.mdx
+++ b/docs/explanation/agent-internals.mdx
@@ -71,8 +71,8 @@ Once connected, an agent will receive chunks of audio as [`AgentRequest.TrackDat
 
 ### Step 4. Disconnecting from the Room
 
-An agent disconnects from the room by closing the WebSocket connection created in [Step 2](#step-2.-connecting-to-the-room).
-It may reconnect using the same token it provided in [Step 2](#step-2.-connecting-to-the-room).
+An agent disconnects from the room by closing the WebSocket connection created in [Step 2](#step-2-connecting-to-the-room).
+It may reconnect using the same token it provided in [Step 2](#step-2-connecting-to-the-room).
 
 ## Peer subscriptions
 

--- a/docs/tutorials/agents.mdx
+++ b/docs/tutorials/agents.mdx
@@ -183,7 +183,7 @@ If you are using the server SDKs, then creating an agent and defining its behavi
 
 </Tabs>
 
-If you are using Fishjam's REST API directly, then check out this [Agent Internals section](../explanation/agent-internals#rest-api).
+If you are using Fishjam's REST API directly, then check out this [Agent Internals section](../explanation/agent-internals#step-1-creating-an-agent-in-fishjam).
 
 ## Pricing
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -135,6 +135,7 @@ const config: Config = {
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
+  onBrokenAnchors: "throw",
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -134,8 +134,9 @@ const config: Config = {
   projectName: "documentation",
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+  onBrokenMarkdownLinks: "throw",
   onBrokenAnchors: "throw",
+  onDuplicateRoutes: "throw",
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/versioned_docs/version-0.21.0/explanation/agent-internals.mdx
+++ b/versioned_docs/version-0.21.0/explanation/agent-internals.mdx
@@ -71,8 +71,8 @@ Once connected, an agent will receive chunks of audio as [`AgentRequest.TrackDat
 
 ### Step 4. Disconnecting from the Room
 
-An agent disconnects from the room by closing the WebSocket connection created in [Step 2](#step-2.-connecting-to-the-room).
-It may reconnect using the same token it provided in [Step 2](#step-2.-connecting-to-the-room).
+An agent disconnects from the room by closing the WebSocket connection created in [Step 2](#step-2-connecting-to-the-room).
+It may reconnect using the same token it provided in [Step 2](#step-2-connecting-to-the-room).
 
 ## Peer subscriptions
 

--- a/versioned_docs/version-0.21.0/tutorials/agents.mdx
+++ b/versioned_docs/version-0.21.0/tutorials/agents.mdx
@@ -183,7 +183,7 @@ If you are using the server SDKs, then creating an agent and defining its behavi
 
 </Tabs>
 
-If you are using Fishjam's REST API directly, then check out this [Agent Internals section](../explanation/agent-internals#rest-api).
+If you are using Fishjam's REST API directly, then check out this [Agent Internals section](../explanation/agent-internals#step-1-creating-an-agent-in-fishjam).
 
 ## Pricing
 


### PR DESCRIPTION
## Description

Link to `Step 2` had `.` and `rest-api` section in agent internals does not exist so I linked it to `Step 1` instead
