### PR TITLE
FCE-2713: Add llms.txt to docs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -339,6 +339,16 @@ const config: Config = {
         ...typedocConfig,
       },
     ],
+    [
+      "docusaurus-plugin-llms",
+      {
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        title: "Fishjam Docs",
+        description:
+          "Fishjam is a multimedia streaming toolkit for building real-time video and audio applications with managed WebRTC infrastructure, client SDKs (React, React Native), and server SDKs (Node.js, Python).",
+      },
+    ],
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@google/genai": "^1.35.0",
     "@shikijs/twoslash": "^3.6.0",
     "cspell": "^9.1.2",
+    "docusaurus-plugin-llms": "^0.3.0",
     "docusaurus-plugin-typedoc": "1.4.0",
     "prettier": "^3.5.3",
     "typedoc": "0.28.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8203,7 +8203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
+"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
   version: 2.0.2
   resolution: "brace-expansion@npm:2.0.2"
   dependencies:
@@ -10256,6 +10256,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"docusaurus-plugin-llms@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "docusaurus-plugin-llms@npm:0.3.0"
+  dependencies:
+    gray-matter: "npm:^4.0.3"
+    minimatch: "npm:^9.0.3"
+    yaml: "npm:^2.8.1"
+  peerDependencies:
+    "@docusaurus/core": ^3.0.0
+  checksum: 10c0/39b1284a512b2226330a1c39919a5087d7b7b482951478e0f26f16d62c2f05eee2585661635f6ac1636526f5c8de576066dc68a449253d86a9ebce93f6df2514
+  languageName: node
+  linkType: hard
+
 "docusaurus-plugin-typedoc@npm:1.4.0":
   version: 1.4.0
   resolution: "docusaurus-plugin-typedoc@npm:1.4.0"
@@ -11348,6 +11361,7 @@ __metadata:
     clsx: "npm:^2.0.0"
     cspell: "npm:^9.1.2"
     docusaurus-lunr-search: "npm:3.6.0"
+    docusaurus-plugin-llms: "npm:^0.3.0"
     docusaurus-plugin-typedoc: "npm:1.4.0"
     expo-camera: "npm:^16.1.8"
     fastify: "npm:^5.4.0"
@@ -15229,6 +15243,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.3":
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
+  dependencies:
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 
@@ -20967,6 +20990,15 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/f6f7310cf7264a8107e72c1376f4de37389945d2fb4656f8060eca83f01d2d703f9d1b925dd8f39852a57034fafefde6225409ddd9f22aebfda16c6141b71858
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.1":
+  version: 2.8.2
+  resolution: "yaml@npm:2.8.2"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/703e4dc1e34b324aa66876d63618dcacb9ed49f7e7fe9b70f1e703645be8d640f68ab84f12b86df8ac960bac37acf5513e115de7c970940617ce0343c8c9cd96
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Adds `docusaurus-plugin-llms` to automatically generate `llms.txt` and `llms-full.txt` at build time
- Follows the [llmstxt.org](https://llmstxt.org/) standard for LLM-friendly documentation
- No manual maintenance needed — files are regenerated on every build

## Test plan
- [ ] Verify the build succeeds in CI
- [ ] Check that `llms.txt` and `llms-full.txt` are present in the build output
- [ ] Verify `https://docs.fishjam.io/llms.txt` is accessible after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)