### PR TITLE
FCE-3048: Enhance documentation PiP section about background calls

### DIFF
--- a/docs/examples/react-native.mdx
+++ b/docs/examples/react-native.mdx
@@ -177,4 +177,4 @@ Browse the full source: [video-player on GitHub](https://github.com/fishjam-clou
 - Follow the [React Native Quick Start](../tutorials/react-native-quick-start) if you haven't set up a project yet
 - Learn how to [handle screen sharing](../how-to/client/screensharing)
 - Learn how to [implement background streaming](../how-to/client/background-streaming)
-- Learn how to [work with data channels](../how-to/client/data-channels)
+- Learn how to [work with data channels](../how-to/features/text-chat)

--- a/docs/examples/react.mdx
+++ b/docs/examples/react.mdx
@@ -188,5 +188,5 @@ Browse the full source: [fishjam-chat on GitHub](https://github.com/fishjam-clou
 ## Next steps
 
 - Follow the [React Quick Start](../tutorials/react-quick-start) if you haven't set up a project yet
-- Learn how to [work with data channels](../how-to/client/data-channels)
+- Learn how to [work with data channels](../how-to/features/text-chat)
 - Learn how to [implement screen sharing](../how-to/client/screensharing)

--- a/docs/how-to/client/background-streaming.mdx
+++ b/docs/how-to/client/background-streaming.mdx
@@ -140,7 +140,7 @@ On iOS, background calls are achieved through CallKit integration. You can use t
 
 ### Manual CallKit Management
 
-Use the [`useCallKit`](../../api/mobile/variables/useCallKit) hook for fine-grained control over CallKit sessions:
+Use the [`useCallKit`](../../api/mobile/functions/useCallKit) hook for fine-grained control over CallKit sessions:
 
 ```tsx
 import { useCallKit } from "@fishjam-cloud/react-native-client";
@@ -165,7 +165,7 @@ const handleLeaveRoom = async () => {
 
 ### Automatic CallKit Management
 
-Use the [`useCallKitService`](../../api/mobile/variables/useCallKitService) hook for automatic session lifecycle management:
+Use the [`useCallKitService`](../../api/mobile/functions/useCallKitService) hook for automatic session lifecycle management:
 
 ```tsx
 import React from "react";
@@ -186,7 +186,7 @@ function CallScreen({ username }: { username: string }) {
 
 ### Listening to CallKit Events
 
-Use the [`useCallKitEvent`](../../api/mobile/variables/useCallKitEvent) hook to respond to user interactions with the native CallKit interface:
+Use the [`useCallKitEvent`](../../api/mobile/functions/useCallKitEvent) hook to respond to user interactions with the native CallKit interface:
 
 ```tsx
 import {

--- a/docs/how-to/client/list-other-peers.mdx
+++ b/docs/how-to/client/list-other-peers.mdx
@@ -50,7 +50,11 @@ export function Component() {
 ```tsx
 import React from "react";
 import { View, Text } from "react-native";
-import { usePeers, RTCView } from "@fishjam-cloud/react-native-client";
+import {
+  usePeers,
+  RTCView,
+  type MediaStream,
+} from "@fishjam-cloud/react-native-client";
 
 function VideoPlayer({ stream }: { stream: MediaStream | null }) {
   if (!stream) return <Text>No video</Text>;

--- a/docs/how-to/client/managing-devices.mdx
+++ b/docs/how-to/client/managing-devices.mdx
@@ -168,7 +168,7 @@ Use the [`toggleMicrophone()`](../../api/web/functions/useMicrophone#togglemicro
   </TabItem>
   <TabItem value="mobile" label="React Native (Mobile)">
 
-You can use [`toggleMicrophone`](../../api/mobile/variables/useMicrophone) to toggle the microphone state, or use [`startMicrophone`](../../api/mobile/variables/useMicrophone) and [`stopMicrophone`](../../api/mobile/variables/useMicrophone) for more explicit control.
+You can use [`toggleMicrophone`](../../api/mobile/functions/useMicrophone) to toggle the microphone state, or use [`startMicrophone`](../../api/mobile/functions/useMicrophone) and [`stopMicrophone`](../../api/mobile/functions/useMicrophone) for more explicit control.
 
 #### Using toggleMicrophone
 

--- a/docs/how-to/client/migration-guide.mdx
+++ b/docs/how-to/client/migration-guide.mdx
@@ -148,7 +148,11 @@ const localTrack = localPeer?.tracks.find((t) => t.type === "Video");
 ```tsx
 import React from "react";
 // ---cut---
-import { usePeers, RTCView } from "@fishjam-cloud/react-native-client";
+import {
+  usePeers,
+  RTCView,
+  type MediaStream,
+} from "@fishjam-cloud/react-native-client";
 
 function VideoPlayer({ stream }: { stream: MediaStream | null | undefined }) {
   return (

--- a/docs/how-to/client/picture-in-picture.mdx
+++ b/docs/how-to/client/picture-in-picture.mdx
@@ -308,6 +308,7 @@ import {
   startPIP,
   stopPIP,
   usePeers,
+  type MediaStream,
 } from "@fishjam-cloud/react-native-client";
 
 function VideoPlayer({ stream }: { stream: MediaStream | null }) {

--- a/docs/how-to/client/picture-in-picture.mdx
+++ b/docs/how-to/client/picture-in-picture.mdx
@@ -86,6 +86,12 @@ Add the `audio` background mode to your `Info.plist`:
 </array>
 ```
 
+:::tip[When do you need `voip`?]
+The `audio` background mode is sufficient for PiP itself. The microphone continues to work in the background with just `audio`, but if your app also needs to keep the **camera** active while in the background (e.g., an ongoing video call), you need the `voip` background mode. See the [Background calls](./background-streaming) guide for setup instructions.
+
+Adding `voip` to `UIBackgroundModes` triggers additional scrutiny during Apple's App Store review — only add it if your app genuinely requires VoIP functionality.
+:::
+
   </TabItem>
 </Tabs>
 
@@ -378,7 +384,11 @@ Picture in Picture is supported on Android 8.0 (API level 26) and above. The sys
 
 #### iOS
 
-Picture in Picture requires the `audio` background mode. When `allowsCameraInBackground` is enabled, the camera continues to capture in PiP mode (iOS 16.0+). Picture in Picture works seamlessly with CallKit for native call integration.
+Picture in Picture on iOS can be used both while the app is in the foreground (as an in-app overlay) and when the app is backgrounded. The `audio` background mode is required for PiP to continue displaying video after the app moves to the background.
+
+With only the `audio` background mode, the microphone continues to work but the outgoing camera track stops when the app is backgrounded. This is sufficient for audio-only calls or receive-only scenarios like livestream viewing. For video calls where the camera needs to keep working in the background, the `voip` background mode is additionally required — see the [Background calls](./background-streaming) guide.
+
+When `allowsCameraInBackground` is enabled together with the `voip` background mode, the camera continues to capture in PiP mode (iOS 16.0+).
 
 ### Active Speaker Detection
 
@@ -386,9 +396,18 @@ The secondary view (right side) automatically displays the remote participant wh
 
 This automatic switching ensures the most relevant video is always displayed in the Picture in Picture window.
 
-### Combining with Background Streaming
+### Combining with Background Calls
 
-Picture in Picture works great with [background streaming](./background-streaming). When both features are enabled, use foreground services on **Android** to keep the call active in the background, and use CallKit integration along with VoIP background mode on **iOS**.
+If your app needs to keep the camera active during a video call while in the background, PiP alone is not enough. Without the `voip` background mode on iOS, PiP displays received video and the microphone continues to work, but the outgoing camera track stops when the app is backgrounded.
+
+To keep a full two-way call active in the background with a PiP overlay, combine PiP with [background calls](./background-streaming):
+
+- **Android**: Enable foreground services alongside PiP.
+- **iOS**: Enable the `voip` background mode alongside PiP.
+
+:::caution
+Adding `voip` to `UIBackgroundModes` triggers additional scrutiny during Apple's App Store review. Only enable it if your app genuinely requires VoIP functionality (active calls in the background). For receive-only scenarios like livestream viewing, the `audio` background mode configured during [PiP installation](#installation) is sufficient.
+:::
 
 Example configuration combining both features:
 

--- a/docs/how-to/client/screensharing.mdx
+++ b/docs/how-to/client/screensharing.mdx
@@ -214,11 +214,11 @@ Configuring screen sharing on iOS is a little complicated.
 
 ## Usage
 
-You can use [`useScreenShare`](../../api/mobile/variables/useScreenShare) hook to enable screen sharing.
+You can use [`useScreenShare`](../../api/mobile/functions/useScreenShare) hook to enable screen sharing.
 
 :::tip[Permissions]
 
-Permission request is handled for you as soon as you call [`startStreaming`](../../api/mobile/variables/useScreenShare#startstreaming).
+Permission request is handled for you as soon as you call [`startStreaming`](../../api/mobile/functions/useScreenShare#startstreaming).
 
 :::
 
@@ -228,8 +228,8 @@ On Android API level >= 24, you must use a foreground service when screen sharin
 
 :::
 
-You can enable/disable screen sharing with [`startStreaming`](../../api/mobile/variables/useScreenShare#startstreaming) and [`stopStreaming`](../../api/mobile/variables/useScreenShare#stopstreaming) methods.
-And check current state by checking if [`stream`](../../api/mobile/variables/useScreenShare#stream) exists.
+You can enable/disable screen sharing with [`startStreaming`](../../api/mobile/functions/useScreenShare#startstreaming) and [`stopStreaming`](../../api/mobile/functions/useScreenShare#stopstreaming) methods.
+And check current state by checking if [`stream`](../../api/mobile/functions/useScreenShare#stream) exists.
 
 ```tsx
 import React, { useCallback } from "react";

--- a/docs/how-to/client/start-streaming.mdx
+++ b/docs/how-to/client/start-streaming.mdx
@@ -98,7 +98,7 @@ export function ExampleCameraPreview() {
   </TabItem>
   <TabItem value="mobile" label="React Native (Mobile)">
 
-To manage users' camera and microphone devices, use the respective [`useCamera`](../../api/mobile/functions/useCamera) and [`useMicrophone`](../../api/mobile/variables/useMicrophone) hooks. Both of them have similar API. To keep things simple, we will just use the camera hook.
+To manage users' camera and microphone devices, use the respective [`useCamera`](../../api/mobile/functions/useCamera) and [`useMicrophone`](../../api/mobile/functions/useMicrophone) hooks. Both of them have similar API. To keep things simple, we will just use the camera hook.
 
 You can preview your camera stream using the `RTCView` component.
 

--- a/docs/how-to/features/text-chat.mdx
+++ b/docs/how-to/features/text-chat.mdx
@@ -16,7 +16,7 @@ This guide shows how to implement text chat in your application using data chann
 Before implementing text chat, you must be [connected to a room](../client/connecting). Data channels only work after you have successfully joined a room.
 
 :::tip
-For a deeper understanding of how data channels work, including channel types and broadcast behavior, see [Data Channels](../explanation/data-channels).
+For a deeper understanding of how data channels work, including channel types and broadcast behavior, see [Data Channels](../../explanation/data-channels).
 :::
 
 ---

--- a/docs/tutorials/gemini-live-integration.mdx
+++ b/docs/tutorials/gemini-live-integration.mdx
@@ -70,7 +70,7 @@ We provide a helper factory to initialize the Google Client.
   
     ```ts
     import { FishjamClient } from '@fishjam-cloud/js-server-sdk';
-    import * as GeminiIntegration from '@fishjam-cloud/js-server-sdk/gemini';
+    import GeminiIntegration from '@fishjam-cloud/js-server-sdk/gemini';
 
     const fishjamClient = new FishjamClient({
       fishjamId: process.env.FISHJAM_ID!,
@@ -120,7 +120,7 @@ Create a Fishjam agent configured to match the audio format that the Google clie
     const fishjamClient = new FishjamClient({ fishjamId, managementToken });
     
     // ---cut---
-    import * as GeminiIntegration from '@fishjam-cloud/js-server-sdk/gemini';
+    import GeminiIntegration from '@fishjam-cloud/js-server-sdk/gemini';
     
     const room = await fishjamClient.createRoom();
     
@@ -181,7 +181,7 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
 
 
     // ---cut---
-    import * as GeminiIntegration from '@fishjam-cloud/js-server-sdk/gemini';
+    import GeminiIntegration from '@fishjam-cloud/js-server-sdk/gemini';
     import { Modality } from '@google/genai';
 
     const GEMINI_MODEL = 'gemini-2.5-flash-native-audio-preview-12-2025'

--- a/docs/tutorials/livestreaming.mdx
+++ b/docs/tutorials/livestreaming.mdx
@@ -205,7 +205,7 @@ We can now start sending media, which we can obtain from the user's camera, scre
       If you want to continue screen sharing when the app goes to the background, you need to:
 
       1. Enable VoIP background mode by setting `enableVoIPBackgroundMode: true` in the plugin configuration or adding the VoIP background mode to your `Info.plist`
-      2. Use the [`useCallKitService`](../../api/mobile/variables/useCallKitService) hook in your component to manage the CallKit session
+      2. Use the [`useCallKitService`](../../api/mobile/functions/useCallKitService) hook in your component to manage the CallKit session
 
       See the [background calls documentation](../how-to/client/background-streaming) for detailed instructions and code examples.
 

--- a/docs/tutorials/react-native-quick-start.mdx
+++ b/docs/tutorials/react-native-quick-start.mdx
@@ -255,7 +255,11 @@ Show video from other peers in the room:
 ```tsx
 import React from "react";
 import { View, Text } from "react-native";
-import { usePeers, RTCView } from "@fishjam-cloud/react-native-client";
+import {
+  usePeers,
+  RTCView,
+  type MediaStream,
+} from "@fishjam-cloud/react-native-client";
 
 function VideoPlayer({ stream }: { stream: MediaStream | null | undefined }) {
   return (
@@ -305,6 +309,7 @@ import {
   useInitializeDevices,
   useSandbox,
   RTCView,
+  type MediaStream,
 } from "@fishjam-cloud/react-native-client";
 
 // Check https://fishjam.io/app/ for your Fishjam ID


### PR DESCRIPTION
## Description

- clarify iOS PiP vs `UIBackgroundModes` — `audio` for PiP; `voip` only when the camera must stay on in the background; mic works with `audio` alone.