### PR TITLE
Fix type errors in Python docs snippets

### DIFF
--- a/docs/explanation/livestreams.mdx
+++ b/docs/explanation/livestreams.mdx
@@ -46,7 +46,7 @@ By default, created livestreams are `private`, to prevent possible bugs.
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
-    );
+    )
 
     private_room = fishjam_client.create_room(RoomOptions(room_type="livestream")) # [!code highlight]
     public_room = fishjam_client.create_room(RoomOptions(room_type="livestream", public=True)) # [!code highlight]
@@ -98,7 +98,7 @@ Note that for development purposes, you can [use the Sandbox API to generate a v
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
-    );
+    )
 
     private_room = fishjam_client.create_room(RoomOptions(room_type="livestream"))
     viewer_token = fishjam_client.create_livestream_viewer_token(private_room.id) # [!code highlight]

--- a/docs/explanation/livestreams.mdx
+++ b/docs/explanation/livestreams.mdx
@@ -41,15 +41,15 @@ By default, created livestreams are `private`, to prevent possible bugs.
   <TabItem value="python" label="Python">
 
     ```python
-    from fishjam import FishjamClient
+    from fishjam import FishjamClient, RoomOptions
 
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
     );
 
-    private_room = fishjam_client.create_room(room_type="livestream") # [!code highlight]
-    public_room = fishjam_client.create_room(room_type="livestream", public=True) # [!code highlight]
+    private_room = fishjam_client.create_room(RoomOptions(room_type="livestream")) # [!code highlight]
+    public_room = fishjam_client.create_room(RoomOptions(room_type="livestream", public=True)) # [!code highlight]
     ```
 
   </TabItem>
@@ -93,14 +93,14 @@ Note that for development purposes, you can [use the Sandbox API to generate a v
   <TabItem value="python" label="Python">
 
     ```python
-    from fishjam import FishjamClient
+    from fishjam import FishjamClient, RoomOptions
 
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
     );
 
-    private_room = fishjam_client.create_room(room_type="livestream")
+    private_room = fishjam_client.create_room(RoomOptions(room_type="livestream"))
     viewer_token = fishjam_client.create_livestream_viewer_token(private_room.id) # [!code highlight]
     ```
 

--- a/docs/how-to/backend/fastapi-example.mdx
+++ b/docs/how-to/backend/fastapi-example.mdx
@@ -77,8 +77,9 @@ It doesn't interact with the FastAPI library per se, just start the event loop a
 ```python
 import asyncio
 from fishjam import FishjamNotifier
+from fishjam.events import ServerMessagePeerAdded
 
-notifier = FishjamNotifier(server_address=fishjam_id, server_api_token=management_token)
+notifier = FishjamNotifier(fishjam_id=fishjam_id, management_token=management_token)
 
 @notifier.on_server_notification
 def handle_notification(notification):

--- a/docs/how-to/backend/server-setup.mdx
+++ b/docs/how-to/backend/server-setup.mdx
@@ -276,6 +276,7 @@ It sets up a websocket connection with a Fishjam instance and provides a simple 
     ```python
     import asyncio
     from fishjam import FishjamNotifier
+    from fishjam.events import ServerMessageRoomCreated
 
     notifier = FishjamNotifier(fishjam_id, management_token)
 

--- a/docs/how-to/backend/whip-whep.mdx
+++ b/docs/how-to/backend/whip-whep.mdx
@@ -71,14 +71,14 @@ You can read about this in detail in [Production Livestreaming with Server SDKs]
   <TabItem value="python" label="Python">
 
     ```python
-    from fishjam import FishjamClient
+    from fishjam import FishjamClient, RoomOptions
 
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
     );
 
-    room = fishjam_client.create_room(room_type="livestream")
+    room = fishjam_client.create_room(RoomOptions(room_type="livestream"))
     streamer_token = fishjam_client.create_livestream_streamer_token(room.id) # [!code highlight]
     ```
 
@@ -150,14 +150,14 @@ You can read about this in detail in [Production Livestreaming with Server SDKs]
   <TabItem value="python" label="Python">
 
     ```python
-    from fishjam import FishjamClient
+    from fishjam import FishjamClient, RoomOptions
 
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
     );
 
-    room = fishjam_client.create_room(room_type="livestream", public=False)
+    room = fishjam_client.create_room(RoomOptions(room_type="livestream", public=False))
 
     # ...
 

--- a/docs/how-to/backend/whip-whep.mdx
+++ b/docs/how-to/backend/whip-whep.mdx
@@ -76,7 +76,7 @@ You can read about this in detail in [Production Livestreaming with Server SDKs]
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
-    );
+    )
 
     room = fishjam_client.create_room(RoomOptions(room_type="livestream"))
     streamer_token = fishjam_client.create_livestream_streamer_token(room.id) # [!code highlight]
@@ -155,7 +155,7 @@ You can read about this in detail in [Production Livestreaming with Server SDKs]
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
-    );
+    )
 
     room = fishjam_client.create_room(RoomOptions(room_type="livestream", public=False))
 

--- a/docs/integrations/gemini-live-integration.mdx
+++ b/docs/integrations/gemini-live-integration.mdx
@@ -227,14 +227,10 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
     Now we connect the websocket loops. We need to forward incoming Fishjam audio to Google, and forward incoming Google audio to Fishjam.
     ```python
     import asyncio
-    import os
-    from google import genai
     from google.genai.types import Blob, Modality
     from fishjam.integrations.gemini import GeminiIntegration
 
     GEMINI_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
-
-    genai_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 
     async def run():
         async with agent.connect() as fishjam_session:
@@ -242,7 +238,7 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
             # Use our preset to match the required audio format (24kHz)
             outgoing_track = await fishjam_session.add_track(GeminiIntegration.GEMINI_OUTPUT_AUDIO_SETTINGS)
 
-            async with genai_client.aio.live.connect(
+            async with gen_ai.aio.live.connect(
                 model=GEMINI_MODEL,
                 config={"response_modalities": [Modality.AUDIO]}
             ) as gemini_session:

--- a/docs/integrations/gemini-live-integration.mdx
+++ b/docs/integrations/gemini-live-integration.mdx
@@ -227,50 +227,57 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
     Now we connect the websocket loops. We need to forward incoming Fishjam audio to Google, and forward incoming Google audio to Fishjam.
     ```python
     import asyncio
-    from fishjam.integrations.gemini import GeminiIntegration
+    import os
+    from google import genai
     from google.genai.types import Blob, Modality
+    from fishjam.integrations.gemini import GeminiIntegration
 
     GEMINI_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
 
-    async with agent.connect() as fishjam_session:
+    genai_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 
-        # Use our preset to match the required audio format (24kHz)
-        outgoing_track = await fishjam_session.add_track(GeminiIntegration.GEMINI_OUTPUT_AUDIO_SETTINGS)
+    async def run():
+        async with agent.connect() as fishjam_session:
 
-        async with gen_ai.aio.live.connect(
-            model=GEMINI_MODEL,
-            config={"response_modalities": [Modality.AUDIO]}
-        ) as gemini_session:
+            # Use our preset to match the required audio format (24kHz)
+            outgoing_track = await fishjam_session.add_track(GeminiIntegration.GEMINI_OUTPUT_AUDIO_SETTINGS)
 
-            # Fishjam -> Google
-            async def forward_audio_to_gemini():
-                async for track_data in fishjam_session.receive():
-                    await gemini_session.send_realtime_input(audio=Blob(
-                        mime_type=GeminiIntegration.GEMINI_AUDIO_MIME_TYPE,
-                        data=track_data.data
-                    ))
+            async with genai_client.aio.live.connect(
+                model=GEMINI_MODEL,
+                config={"response_modalities": [Modality.AUDIO]}
+            ) as gemini_session:
 
-            # Google -> Fishjam
-            async def forward_audio_to_fishjam():
-                async for msg in gemini_session.receive():
-                    server_content = msg.server_content
+                # Fishjam -> Google
+                async def forward_audio_to_gemini():
+                    async for track_data in fishjam_session.receive():
+                        await gemini_session.send_realtime_input(audio=Blob(
+                            mime_type=GeminiIntegration.GEMINI_AUDIO_MIME_TYPE,
+                            data=track_data.data
+                        ))
 
-                    if server_content is None:
-                        continue
+                # Google -> Fishjam
+                async def forward_audio_to_fishjam():
+                    async for msg in gemini_session.receive():
+                        server_content = msg.server_content
 
-                    if server_content.interrupted:
-                        await outgoing_track.interrupt()
+                        if server_content is None:
+                            continue
 
-                    if server_content.model_turn and server_content.model_turn.parts:
-                        for part in server_content.model_turn.parts:
-                            if part.inline_data and part.inline_data.data:
-                                await outgoing_track.send_chunk(part.inline_data.data)
+                        if server_content.interrupted:
+                            await outgoing_track.interrupt()
 
-            # Run both loops concurrently
-            await asyncio.gather(
-                forward_audio_to_gemini(),
-                forward_audio_to_fishjam()
-            )
+                        if server_content.model_turn and server_content.model_turn.parts:
+                            for part in server_content.model_turn.parts:
+                                if part.inline_data and part.inline_data.data:
+                                    await outgoing_track.send_chunk(part.inline_data.data)
+
+                # Run both loops concurrently
+                await asyncio.gather(
+                    forward_audio_to_gemini(),
+                    forward_audio_to_fishjam()
+                )
+
+    asyncio.run(run())
     ```
 
   </TabItem>

--- a/docs/integrations/vapi-integration.mdx
+++ b/docs/integrations/vapi-integration.mdx
@@ -50,7 +50,7 @@ You will need:
   <TabItem value="python" label="Python">
 
     ```bash
-    pip install fishjam-server-sdk vapi
+    pip install fishjam-server-sdk vapi_server_sdk
     ```
 
   </TabItem>

--- a/docs/integrations/vapi-integration.mdx
+++ b/docs/integrations/vapi-integration.mdx
@@ -93,7 +93,7 @@ You can reference an existing assistant by its ID, or create a transient assista
 
     ```python
     import os
-    from vapi_server_sdk import Vapi
+    from vapi import Vapi
 
     vapi_client = Vapi(token=os.environ["VAPI_API_KEY"])
 

--- a/docs/integrations/vapi-integration.mdx
+++ b/docs/integrations/vapi-integration.mdx
@@ -93,7 +93,7 @@ You can reference an existing assistant by its ID, or create a transient assista
 
     ```python
     import os
-    from vapi import Vapi
+    from vapi_server_sdk import Vapi
 
     vapi_client = Vapi(token=os.environ["VAPI_API_KEY"])
 

--- a/docs/tutorials/agents.mdx
+++ b/docs/tutorials/agents.mdx
@@ -377,10 +377,14 @@ After you're done using an agent, you can disconnect it from the room.
   <TabItem value="python" label="Python">
 
     ```python
+    import asyncio
+
     async def run():
         # the agent will disconnect once you exit the context
         async with agent.connect() as session:
             pass
+
+    asyncio.run(run())
     ```
 
   </TabItem>

--- a/docs/tutorials/agents.mdx
+++ b/docs/tutorials/agents.mdx
@@ -108,19 +108,23 @@ However, it's likely that in your scenario you'll want to use the [Selective Sub
   <TabItem value="python" label="Python">
 
     ```python
-    from fishjam import FishjamClient
-    from fishjam.agent import AgentResponseTrackData
+    import asyncio
+    from fishjam import FishjamClient, AgentOptions
+    from fishjam.agent import IncomingTrackData
 
     fishjam_client = FishjamClient(fishjam_id, management_token)
 
     agent_options = AgentOptions(subscribe_mode="auto")
-    agent = fishjam_client.create_agent(room_id)
+    agent = fishjam_client.create_agent(room_id, agent_options)
 
-    # the agent will disconnect once you exit the context
-    async with agent.connect() as session:
-      async for track_data in session.receive():
-        # process the incoming data
-        pass
+    async def run():
+        # the agent will disconnect once you exit the context
+        async with agent.connect() as session:
+            async for track_data in session.receive():
+                # process the incoming data
+                pass
+
+    asyncio.run(run())
     ```
 
   </TabItem>
@@ -239,28 +243,33 @@ You can interrupt the currently played audio chunk. See the example below.
   <TabItem value="python" label="Python">
 
     ```python
-    from fishjam import FishjamClient
-    from fishjam.agent import AgentResponseTrackData, OutgoingAudioTrackOptions, TrackEncoding
+    import asyncio
+    from fishjam import FishjamClient, AgentOptions
+    from fishjam.agent import OutgoingAudioTrackOptions
+    from fishjam.events import TrackEncoding
 
     fishjam_client = FishjamClient(fishjam_id, management_token)
 
     agent_options = AgentOptions(subscribe_mode="auto")
 
-    agent = fishjam_client.create_agent(room_id)
+    agent = fishjam_client.create_agent(room_id, agent_options)
 
-    track_options = OutgoingAudioTrackOptions(encoding=TrackEncoding.PCM16)
+    track_options = OutgoingAudioTrackOptions(encoding=TrackEncoding.TRACK_ENCODING_PCM16)
 
-    # the agent will disconnect once you exit the context
-    async with agent.connect() as session:
-        outgoing_track = session.create_track(track_options)
+    async def run():
+        # the agent will disconnect once you exit the context
+        async with agent.connect() as session:
+            outgoing_track = await session.add_track(track_options)
 
-        # that's a dummy chatbot
-        async for chatbot_data in chatbot.receive():
-            outgoing_track.send_chunk(chatbot_data)
+            # that's a dummy chatbot
+            async for chatbot_data in chatbot.receive():
+                await outgoing_track.send_chunk(chatbot_data)
 
-        # you're able to interrupt the currently played audio chunk
-        # [!code highlight:1]
-        ongoing_track.interrupt()
+            # you're able to interrupt the currently played audio chunk
+            # [!code highlight:1]
+            await outgoing_track.interrupt()
+
+    asyncio.run(run())
     ```
 
   </TabItem>
@@ -321,18 +330,21 @@ Video frame capture is rate-limited to one frame per second per track.
 
     agent = fishjam_client.create_agent(room_id)
 
-    async with agent.connect() as session:
-        # Request a frame
-        # [!code highlight:1]
-        await session.capture_image(track_id)
+    async def run():
+        async with agent.connect() as session:
+            # Request a frame
+            # [!code highlight:1]
+            await session.capture_image(track_id)
 
-        # Captured frames arrive as IncomingTrackImage messages
-        async for message in session.receive():
-            match message:
-                case IncomingTrackImage() as msg if msg.track_id == track_id:
-                    data = msg.data
-                    # process the image data
-                    pass
+            # Captured frames arrive as IncomingTrackImage messages
+            async for message in session.receive():
+                match message:
+                    case IncomingTrackImage() as msg if msg.track_id == track_id:
+                        data = msg.data
+                        # process the image data
+                        pass
+
+    asyncio.run(run())
     ```
 
   </TabItem>
@@ -365,9 +377,10 @@ After you're done using an agent, you can disconnect it from the room.
   <TabItem value="python" label="Python">
 
     ```python
-    # the agent will disconnect once you exit the context
-    async with agent.connect() as session:
-        pass
+    async def run():
+        # the agent will disconnect once you exit the context
+        async with agent.connect() as session:
+            pass
     ```
 
   </TabItem>

--- a/docs/tutorials/backend-quick-start.mdx
+++ b/docs/tutorials/backend-quick-start.mdx
@@ -354,6 +354,7 @@ Build a simple HTTP endpoint that your client apps can call:
     ```python
     import os
     from fastapi import FastAPI, HTTPException
+    from pydantic import BaseModel
     from fishjam import FishjamClient, PeerOptions
 
     app = FastAPI()

--- a/docs/tutorials/livestreaming.mdx
+++ b/docs/tutorials/livestreaming.mdx
@@ -434,7 +434,7 @@ Our backend needs to do three things to be ready for streaming:
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
       management_token=management_token,
-    );
+    )
 
     # 1.
     room = fishjam_client.create_room(RoomOptions(room_type="livestream"))

--- a/docs/tutorials/livestreaming.mdx
+++ b/docs/tutorials/livestreaming.mdx
@@ -429,7 +429,7 @@ Our backend needs to do three things to be ready for streaming:
   <TabItem value="python" label="Python">
 
     ```python
-    from fishjam import FishjamClient
+    from fishjam import FishjamClient, RoomOptions
 
     fishjam_client = FishjamClient(
       fishjam_id=fishjam_id,
@@ -437,7 +437,7 @@ Our backend needs to do three things to be ready for streaming:
     );
 
     # 1.
-    room = fishjam_client.create_room(room_type="livestream")
+    room = fishjam_client.create_room(RoomOptions(room_type="livestream"))
     # 2.
     streamer_token = fishjam_client.create_livestream_streamer_token(room.id)
     # 3.

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -8,7 +8,7 @@ cd $ROOTDIR
 
 printf "Synchronising submodules... "
 git submodule sync --recursive >>/dev/null
-git submodule update --init --recursive --remote >>/dev/null
+git submodule update --init --recursive >>/dev/null
 
 # cd packages/web-client-sdk/
 # yarn && yarn build

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -7,8 +7,8 @@ echo $ROOTDIR
 cd $ROOTDIR
 
 printf "Synchronising submodules... "
-git submodule sync >>/dev/null
-git submodule update --init --remote >>/dev/null
+git submodule sync --recursive >>/dev/null
+git submodule update --init --recursive --remote >>/dev/null
 
 # cd packages/web-client-sdk/
 # yarn && yarn build


### PR DESCRIPTION
## Description
Fixes FCE-3390

Fixes surfaced running typecheck pipeline against Python code snippets:

- create_room calls now pass RoomOptions instead of raw kwargs (livestreams, whip-whep, livestreaming).
- FishjamNotifier uses fishjam_id / management_token kwargs instead of server_address / server_api_token.
- AgentSession.add_track replaces non-existent create_track; matching send_chunk / interrupt calls are awaited.
- Import fixes: IncomingTrackData (was AgentResponseTrackData), TrackEncoding from fishjam.events (was fishjam.agent), TRACK_ENCODING_PCM16 enum value (was PCM16), AgentOptions, ServerMessagePeerAdded, ServerMessageRoomCreated, pydantic.BaseModel, google.genai client wiring.
- vapi_server_sdk replaces non-existent 'vapi' package.
- Top-level async with / await wrapped in async def run() + asyncio.run(run()) so snippets are runnable as written.