### PR TITLE
FCE-2316 Document noise cancellation and auto gain

### DIFF
--- a/docs/how-to/client/managing-devices.mdx
+++ b/docs/how-to/client/managing-devices.mdx
@@ -258,6 +258,62 @@ export function MicrophoneControl() {
 }
 ```
 
+## Audio processing: noise cancellation and auto gain
+
+When capturing a microphone, the browser (Web) or OS (Mobile) applies audio processing — **echo cancellation**, **noise suppression** (noise cancellation) and **auto gain control** — to make speech clearer. These are enabled by default and are the right choice for most voice and meeting use cases.
+
+Turn them off only when you need the raw, unprocessed signal — for example capturing music or an instrument, or running your own audio processing — since these filters can distort non-speech audio.
+
+<Tabs groupId="platform">
+  <TabItem value="web" label="React (Web)">
+
+On Web, audio processing follows the browser's defaults (noise suppression, auto gain control and echo cancellation are on by default). To set them explicitly, pass [`constraints`](../../api/web/interfaces/FishjamProviderProps#constraints) to `FishjamProvider`. The `audio` field accepts standard [`MediaTrackConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints).
+
+```tsx
+import { FishjamProvider } from "@fishjam-cloud/react-client";
+
+export function App({ fishjamId }: { fishjamId: string }) {
+  return (
+    <FishjamProvider
+      fishjamId={fishjamId}
+      constraints={{
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true, // noise cancellation
+          autoGainControl: true,
+        },
+      }}
+    >
+      {/* your app */}
+    </FishjamProvider>
+  );
+}
+```
+
+To capture raw audio (for example, music), disable them:
+
+```tsx
+constraints={{
+  audio: {
+    echoCancellation: false,
+    noiseSuppression: false,
+    autoGainControl: false,
+  },
+}}
+```
+
+:::note
+These constraints are applied when `FishjamProvider` creates the microphone track. `selectMicrophone` and `startMicrophone` reuse the same constraints — they don't accept per-call overrides.
+:::
+
+  </TabItem>
+  <TabItem value="mobile" label="React Native (Mobile)">
+
+On Mobile, echo cancellation, noise suppression and auto gain control are enabled by default in the native audio pipeline and aren't currently configurable from JavaScript.
+
+  </TabItem>
+</Tabs>
+
 ## Managing Permissions (Mobile only)
 
 The SDK provides built-in hooks for querying and requesting device permissions: `useCameraPermissions` and `useMicrophonePermissions` from `@fishjam-cloud/react-native-client`.

--- a/docs/how-to/client/managing-devices.mdx
+++ b/docs/how-to/client/managing-devices.mdx
@@ -270,6 +270,7 @@ Turn them off only when you need the raw, unprocessed signal — for example cap
 On Web, audio processing follows the browser's defaults (noise suppression, auto gain control and echo cancellation are on by default). To set them explicitly, pass [`constraints`](../../api/web/interfaces/FishjamProviderProps#constraints) to `FishjamProvider`. The `audio` field accepts standard [`MediaTrackConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints).
 
 ```tsx
+import React from "react";
 import { FishjamProvider } from "@fishjam-cloud/react-client";
 
 export function App({ fishjamId }: { fishjamId: string }) {
@@ -290,17 +291,7 @@ export function App({ fishjamId }: { fishjamId: string }) {
 }
 ```
 
-To capture raw audio (for example, music), disable them:
-
-```tsx
-constraints={{
-  audio: {
-    echoCancellation: false,
-    noiseSuppression: false,
-    autoGainControl: false,
-  },
-}}
-```
+To capture raw audio (for example, music), set `echoCancellation`, `noiseSuppression`, and `autoGainControl` to `false` instead.
 
 :::note
 These constraints are applied when `FishjamProvider` creates the microphone track. `selectMicrophone` and `startMicrophone` reuse the same constraints — they don't accept per-call overrides.

--- a/docs/how-to/client/managing-devices.mdx
+++ b/docs/how-to/client/managing-devices.mdx
@@ -258,7 +258,7 @@ export function MicrophoneControl() {
 }
 ```
 
-## Audio processing: noise cancellation and auto gain
+## Audio processing: noise cancellation and auto gain control
 
 When capturing a microphone, the browser (Web) or OS (Mobile) applies audio processing — **echo cancellation**, **noise suppression** (noise cancellation) and **auto gain control** — to make speech clearer. These are enabled by default and are the right choice for most voice and meeting use cases.
 


### PR DESCRIPTION
## What

Documents the audio-processing constraints (echo cancellation, **noise suppression / noise cancellation**, and **auto gain control**) for the web client SDK — closes FCE-2316.

Adds an *Audio processing: noise cancellation and auto gain* section to `docs/how-to/client/managing-devices.mdx` (Web/Mobile tabs):
- Explains they are **enabled by default** and when to disable them (raw audio: music, instruments, custom processing).
- **Web:** how to set them explicitly via the `constraints` prop on `FishjamProvider`, with enable + raw-audio examples; notes `selectMicrophone`/`startMicrophone` reuse the provider constraints.
- **Mobile:** enabled by default in the native pipeline, not currently configurable from JS.

## Note on the issue premise

FCE-2316 said "we disable them by default", but `main` of web-client-sdk never sets these constraints (passes `audio: true` → browser defaults, which are **on**), and mobile-client-sdk hardcodes them to `true` natively. So the docs describe the actual behavior (enabled by default) rather than the issue's wording.

## Verification

- cspell: clean
- Internal cross-link `FishjamProviderProps#constraints` resolves