### PR TITLE
Add Troubleshooting Gemini API keys section

### DIFF
--- a/docs/_common/agents/remember-to-disconnect.mdx
+++ b/docs/_common/agents/remember-to-disconnect.mdx
@@ -1,3 +1,3 @@
-:::danger Remember to disconnect your agents!
+:::danger[Remember to disconnect your agents!]
 It's important to disconnect agents, because **every connected agent generates usage** just as a normal peer.
 :::

--- a/docs/integrations/gemini-live-integration.mdx
+++ b/docs/integrations/gemini-live-integration.mdx
@@ -283,8 +283,8 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
 
 If your agent joins the room but silently does nothing — no audio, no transcription, and no error — the problem is almost always the Gemini API key.
 
-:::warning[Errors are asynchronous, not thrown]
-`createClient` is a thin synchronous wrapper around Google's `GoogleGenAI` and makes no network call, so an invalid or unauthorized key is **not** rejected when you create the client. The key is only exercised later, when `live.connect()` opens the Live websocket. Authentication and access failures then surface through the Live session callbacks (`onerror` / `onclose`) — never as a thrown exception.
+:::warning[API key errors surface asynchronously]
+`createClient` is a thin synchronous wrapper around Google's `GoogleGenAI` and makes no network call, so an invalid or unauthorized key is **not** rejected when you create the client. The key is only exercised later, when `live.connect()` opens the Live websocket. Authentication and access failures then typically surface through the Live session callbacks (`onerror` / `onclose`) rather than as a thrown exception. (Other problems, such as a malformed config, can still reject the awaited `connect()` call — keep a `try/catch` around it too.)
 :::
 
 Always implement the `onerror` and `onclose` callbacks and log the close code and reason. That is where the real error message appears:

--- a/docs/integrations/gemini-live-integration.mdx
+++ b/docs/integrations/gemini-live-integration.mdx
@@ -284,10 +284,10 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
 If your agent joins the room but silently does nothing — no audio, no transcription, and no error — the problem is almost always the Gemini API key.
 
 :::warning[API key errors surface asynchronously]
-`createClient` is a thin synchronous wrapper around Google's `GoogleGenAI` and makes no network call, so an invalid or unauthorized key is **not** rejected when you create the client. The key is only exercised later, when `live.connect()` opens the Live websocket. Authentication and access failures then typically surface through the Live session callbacks (`onerror` / `onclose`) rather than as a thrown exception. (Other problems, such as a malformed config, can still reject the awaited `connect()` call — keep a `try/catch` around it too.)
+`createClient` is a thin synchronous wrapper around Google's `GoogleGenAI` and makes no network call, so it does **not** validate your key — an invalid or unauthorized key is not rejected when you create the client. Unless you verify it explicitly (see below), the key is first exercised when `live.connect()` opens the Live websocket, and authentication or access failures then typically surface through the Live session callbacks (`onerror` / `onclose`) rather than as a thrown exception. (Other problems, such as a malformed config, can still reject the awaited `connect()` call — keep a `try/catch` around it too.)
 :::
 
-Always implement the `onerror` and `onclose` callbacks and log the close code and reason. That is where the real error message appears:
+To catch a bad key up front, call `checkCredentials` before connecting: it makes a single network request and throws if the key is rejected, so misconfiguration fails fast instead of silently. Still implement the `onerror` and `onclose` callbacks and log the close code and reason — that is where model-specific rejections (see below) and other Live failures appear:
 
 ```ts
 import GeminiIntegration from "@fishjam-cloud/js-server-sdk/gemini";

--- a/docs/integrations/gemini-live-integration.mdx
+++ b/docs/integrations/gemini-live-integration.mdx
@@ -283,7 +283,7 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
 
 If your agent joins the room but silently does nothing — no audio, no transcription, and no error — the problem is almost always the Gemini API key.
 
-:::warning Errors are asynchronous, not thrown
+:::warning[Errors are asynchronous, not thrown]
 `createClient` is a thin synchronous wrapper around Google's `GoogleGenAI` and makes no network call, so an invalid or unauthorized key is **not** rejected when you create the client. The key is only exercised later, when `live.connect()` opens the Live websocket. Authentication and access failures then surface through the Live session callbacks (`onerror` / `onclose`) — never as a thrown exception.
 :::
 

--- a/docs/integrations/gemini-live-integration.mdx
+++ b/docs/integrations/gemini-live-integration.mdx
@@ -152,7 +152,7 @@ Create a Fishjam agent configured to match the audio format that the Google clie
 
 ### Step 3: Connect the Streams
 
-:::warning Encoding
+:::warning[Encoding]
 Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. Ensure you convert between them correctly as shown below.
 :::
 
@@ -278,3 +278,50 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
 
   </TabItem>
 </Tabs>
+
+## Troubleshooting Gemini API keys
+
+If your agent joins the room but silently does nothing — no audio, no transcription, and no error — the problem is almost always the Gemini API key.
+
+:::warning Errors are asynchronous, not thrown
+`createClient` is a thin synchronous wrapper around Google's `GoogleGenAI` and makes no network call, so an invalid or unauthorized key is **not** rejected when you create the client. The key is only exercised later, when `live.connect()` opens the Live websocket. Authentication and access failures then surface through the Live session callbacks (`onerror` / `onclose`) — never as a thrown exception.
+:::
+
+Always implement the `onerror` and `onclose` callbacks and log the close code and reason. That is where the real error message appears:
+
+```ts
+import GeminiIntegration from "@fishjam-cloud/js-server-sdk/gemini";
+import { Modality, type LiveServerMessage } from "@google/genai";
+
+const genAi = GeminiIntegration.createClient({
+  apiKey: process.env.GOOGLE_API_KEY!,
+});
+const GEMINI_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025";
+const handleMessage = (msg: LiveServerMessage) => {};
+
+// ---cut---
+const session = await genAi.live.connect({
+  model: GEMINI_MODEL,
+  config: { responseModalities: [Modality.AUDIO] },
+  callbacks: {
+    onopen: () => console.log("Gemini Live connected"),
+    onerror: (e) => console.error("Gemini Live error:", e),
+    onclose: (e) =>
+      console.error(`Gemini Live closed: code=${e.code} reason=${e.reason}`),
+    onmessage: handleMessage,
+  },
+});
+```
+
+### Common reasons a key doesn't work
+
+- Wrong or mistyped key, or a key from the wrong Google Cloud project.
+- The Gemini API is not enabled for the key's project.
+- Region or country restriction — the Gemini API (or its free tier) is not available in your region.
+- Model-specific rejection. The native-audio Live models (e.g. `gemini-2.5-flash-native-audio-preview-*`) can reject an otherwise-valid key: the websocket closes with code `1008` and the message _"Your API key was reported as leaked. Please use another API key."_ (even when the key is not actually leaked), or with code `1011` internal errors. A key that works for other models can still fail here.
+
+### How to fix
+
+- Verify or regenerate your key at [Google AI Studio](https://aistudio.google.com/app/apikey).
+- Confirm the Gemini API is enabled for the key's project and that your region is supported.
+- If you see the `1008` "leaked" message, rotate to a freshly generated key.

--- a/docs/integrations/gemini-live-integration.mdx
+++ b/docs/integrations/gemini-live-integration.mdx
@@ -281,7 +281,7 @@ Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. 
 
 ## Troubleshooting Gemini API keys
 
-If your agent joins the room but silently does nothing — no audio, no transcription, and no error — the problem is almost always the Gemini API key.
+If your agent joins the room but silently does nothing — no audio, no transcription, and no error — the issue is often related to the Gemini API key.
 
 :::warning[API key errors surface asynchronously]
 `createClient` is a thin synchronous wrapper around Google's `GoogleGenAI` and makes no network call, so it does **not** validate your key — an invalid or unauthorized key is not rejected when you create the client. Unless you verify it explicitly (see below), the key is first exercised when `live.connect()` opens the Live websocket, and authentication or access failures then typically surface through the Live session callbacks (`onerror` / `onclose`) rather than as a thrown exception. (Other problems, such as a malformed config, can still reject the awaited `connect()` call — keep a `try/catch` around it too.)

--- a/docs/integrations/gemini-live-integration.mdx
+++ b/docs/integrations/gemini-live-integration.mdx
@@ -300,6 +300,8 @@ const GEMINI_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025";
 const handleMessage = (msg: LiveServerMessage) => {};
 
 // ---cut---
+await GeminiIntegration.checkCredentials(genAi);
+
 const session = await genAi.live.connect({
   model: GEMINI_MODEL,
   config: { responseModalities: [Modality.AUDIO] },

--- a/versioned_docs/version-0.26.0/_common/agents/remember-to-disconnect.mdx
+++ b/versioned_docs/version-0.26.0/_common/agents/remember-to-disconnect.mdx
@@ -1,3 +1,3 @@
-:::danger Remember to disconnect your agents!
+:::danger[Remember to disconnect your agents!]
 It's important to disconnect agents, because **every connected agent generates usage** just as a normal peer.
 :::

--- a/versioned_docs/version-0.26.0/integrations/gemini-live-integration.mdx
+++ b/versioned_docs/version-0.26.0/integrations/gemini-live-integration.mdx
@@ -152,7 +152,7 @@ Create a Fishjam agent configured to match the audio format that the Google clie
 
 ### Step 3: Connect the Streams
 
-:::warning Encoding
+:::warning[Encoding]
 Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. Ensure you convert between them correctly as shown below.
 :::
 

--- a/versioned_docs/version-0.26.0/tutorials/livestreaming.mdx
+++ b/versioned_docs/version-0.26.0/tutorials/livestreaming.mdx
@@ -21,7 +21,7 @@ In this tutorial we explain how to publish and view streams with the client SDKs
 If you prefer to use WHIP or WHEP directly, then you should read [WHIP/WHEP with Fishjam](../how-to/backend/whip-whep).
 :::
 
-:::info Cost-effective audio livestreams
+:::info[Cost-effective audio livestreams]
 Fishjam supports audio-only livestreams at a reduced cost of $0.20 per 1000 minutes of the streamer and each listener (compared to $0.80 for video livestreams).  
 This is ideal for podcasts, radio-style broadcasts, or any scenario where video isn't necessary.
 See [Audio-only calls](../how-to/backend/audio-only-calls) for more information.

--- a/versioned_docs/version-0.27.0/_common/agents/remember-to-disconnect.mdx
+++ b/versioned_docs/version-0.27.0/_common/agents/remember-to-disconnect.mdx
@@ -1,3 +1,3 @@
-:::danger Remember to disconnect your agents!
+:::danger[Remember to disconnect your agents!]
 It's important to disconnect agents, because **every connected agent generates usage** just as a normal peer.
 :::

--- a/versioned_docs/version-0.27.0/integrations/gemini-live-integration.mdx
+++ b/versioned_docs/version-0.27.0/integrations/gemini-live-integration.mdx
@@ -152,7 +152,7 @@ Create a Fishjam agent configured to match the audio format that the Google clie
 
 ### Step 3: Connect the Streams
 
-:::warning Encoding
+:::warning[Encoding]
 Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. Ensure you convert between them correctly as shown below.
 :::
 

--- a/versioned_docs/version-0.28.0/_common/agents/remember-to-disconnect.mdx
+++ b/versioned_docs/version-0.28.0/_common/agents/remember-to-disconnect.mdx
@@ -1,3 +1,3 @@
-:::danger Remember to disconnect your agents!
+:::danger[Remember to disconnect your agents!]
 It's important to disconnect agents, because **every connected agent generates usage** just as a normal peer.
 :::

--- a/versioned_docs/version-0.28.0/integrations/gemini-live-integration.mdx
+++ b/versioned_docs/version-0.28.0/integrations/gemini-live-integration.mdx
@@ -152,7 +152,7 @@ Create a Fishjam agent configured to match the audio format that the Google clie
 
 ### Step 3: Connect the Streams
 
-:::warning Encoding
+:::warning[Encoding]
 Fishjam handles raw bytes, while Google GenAI SDKs often expect Base64 strings. Ensure you convert between them correctly as shown below.
 :::
 


### PR DESCRIPTION
Document why a bad Gemini API key fails silently: createClient does no network call, so auth/access failures surface only via the Live session onerror/onclose callbacks. Covers common causes (wrong/mistyped key, wrong project, API not enabled, region block, native-audio 1008 'leaked'/1011 model-specific rejection) and how to fix.
